### PR TITLE
Add ratings for library from Goodreads

### DIFF
--- a/book_ratings.py
+++ b/book_ratings.py
@@ -1,0 +1,63 @@
+# quick and dirty python script to get the ratings of the books in the Marc Andreesen library via the
+# Goodreads API, sort from highest to lowest and output a markdown file for viewing
+from goodreads import client
+import sys
+
+# since we are reading only, no need to authenticate
+# the script expects the api client key and the client secret as the first two arguments to the script
+# you gets these from Goodreads (see https://www.goodreads.com/api for more details and to get your own)
+gc = client.GoodreadsClient(sys.argv[1], sys.argv[2])
+
+# parse the markdown document (table) into lines
+lines = [line.strip() for line in open('books.md')]
+
+# use the table column markdown to parse the header into a list and add fields for the average rating and rating counts
+records = []
+records.append(lines[0].split(' | '))
+records[0].append("Average Rating")
+records[0].append("Ratings Count")
+
+# skip the second line from the markdown file as it is markdown for the table header
+for line in lines[2:]:
+    # within each line use the table column markdown to split into fields
+    record = line.split(' | ')
+
+    # set the default rating to '0.0' and the rating count to '0'
+    average_rating = '0.0'
+    ratings_count = '0'
+
+    # we can only use the Goodreads API to get the ratings data if a link to the book in Goodreads exists
+    if "[Goodreads]" in record[3]:
+        # the Goodreads book id is essentially the part at the end of the link
+        start = record[3].find('(https://www.goodreads.com/book/show/') + len('(https://www.goodreads.com/book/show/')
+        end = record[3].find(')', start)
+        found = record[3][start:end]
+
+        # use the Goodreads API to get the rating data TODO: add error/exception handling!
+        book = gc.book(found)
+        average_rating = book.average_rating
+        ratings_count = book.ratings_count
+
+    # append the rating data to the end of each record
+    record.append(average_rating)
+    record.append(ratings_count)
+    records.append(record)
+
+# cheap way to skip the header and second record which is header markdown TODO: fix this by removing this record up front
+recs = records[1:]
+
+# sort by average rating: highest to lowest
+recs.sort(key=lambda x: float(x[4]), reverse=True)
+
+# write the output to a markdown file similar to the markdown file input into the script
+with open("books_ratings.md", "w") as file:
+    file.write(' | '.join(records[0]) + '\n')
+    file.write(' | '.join(['---', '---', '---', '---', '---', '---']) + '\n')
+    for record in recs:
+        file.write(' | '.join(record) + '\n')
+
+
+
+
+
+

--- a/books_ratings.md
+++ b/books_ratings.md
@@ -1,0 +1,1090 @@
+Book ID | Title | Author | Links | Average Rating | Ratings Count
+--- | --- | --- | --- | --- | ---
+3-C-20 | _The Pogo Candidature_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/0836206878?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652136) | 5.00 | 2
+3-F-11 | _The Race for a New Game Machine_ | David Shippy,  Mickie Phipps | [Amazon](https://www.amazon.com/dp/0806531428?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/19477154) | 5.00 | 1
+4-D-15 | _Computational Complexity_ | Sanjeev Arora, Boaz Barak |  \| [Goodreads](https://www.goodreads.com/book/show/19059020) | 5.00 | 6
+5-B-2 | _Quantum Information Theory and the Foundations of Quantum Mechanics (Oxford Philosophical Monographs)_ | Christopher G. Timpson | [Amazon](https://www.amazon.com/dp/0198748132?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/17269080) | 5.00 | 2
+5-D-26 | _Two Plays (Sun & Moon Classics)_ | Mac Wellman | [Amazon](https://www.amazon.com/dp/155713197X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1257312) | 5.00 | 1
+7-B-5 | _Professional Linux Deployment_ | Mike Banahan,  Michael Boerner, Ian Dickson | [Amazon](https://www.amazon.com/dp/1861002874?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/930216) | 5.00 | 1
+7-B-19 | _Reliable Linux: Assuring High Availability_ | Iain Campbell | [Amazon](https://www.amazon.com/dp/0471070408?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2265696) | 5.00 | 1
+7-D-5 | _Windows Nt Server 4 Unleashed_ | Jason Garms | [Amazon](https://www.amazon.com/dp/0672309335?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4048294) | 5.00 | 1
+7-E-16 | _Pro Jakarta Velocity: From Professional to Expert_ | Rob Harrop | [Amazon](https://www.amazon.com/dp/159059410X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/138186) | 5.00 | 2
+1-D-20 | _Blue Skies: A History of Cable Television_ | Patrick R. Parsons | [Amazon](https://www.amazon.com/dp/1592132871?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2951331) | 4.75 | 2
+3-C-28 | _The Complete Peanuts 1963 to 1966_ | Charles M. Schulz | [Amazon](https://www.amazon.com/dp/B01B98E0C0?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/817601) | 4.69 | 181
+1-C-5 | _On the Air: The Encyclopedia of Old-Time Radio_ | John Dunning | [Amazon](https://www.amazon.com/dp/0195076788?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/572179) | 4.68 | 74
+3-C-25 | _The Complete Peanuts 1950 to 1954_ | Charles M. Schulz | [Amazon](https://www.amazon.com/dp/1560976322?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/54590) | 4.68 | 368
+7-A-9 | _iPhone SDK 3 Programming: Advanced Mobile Development for Apple iPhone and iPod Touch_ | Maher Ali |  \| [Goodreads](https://www.goodreads.com/book/show/6760123) | 4.67 | 6
+8-E-17 | _Jean Monnet: The First Statesman of Interdependence_ | Francois Duchene | [Amazon](https://www.amazon.com/dp/0393034976?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1680000) | 4.67 | 2
+3-C-22 | _Ten Ever-Lovin Blue-Eyed Years with Pogo_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B00QJ0B4TQ?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652113) | 4.66 | 122
+2-C-26 | _Palliative Care: Transforming the Care of Serious Illness_ | Diane E. Meier, Stephen L. Isaacs, Robert Hughes | [Amazon](https://www.amazon.com/dp/047052717X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6804422) | 4.64 | 13
+3-C-33 | _The New Annotated Sherlock Holmes Volume 3_ | Arthur Conan Doyle_ | [Amazon](https://www.amazon.com/dp/B00QPNRNSI?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3583) | 4.61 | 2071
+8-C-6 | _Sunset Limited_ | James Lee Burke | [Amazon](https://www.amazon.com/dp/0385488424?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2228233) | 4.61 | 94
+3-C-26 | _The Complete Peanuts 1955 to 1958_ | Charles M. Schulz | [Amazon](https://www.amazon.com/dp/B00D82274O?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/54587) | 4.59 | 228
+2-B-15 | _A Century of Stop-Motion Animation: From Melies to Aardman_ | Ray Harryhausen, Tony Dalton | [Amazon](https://www.amazon.com/dp/0823099806?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4422565) | 4.58 | 25
+3-C-16 | _Positively Pogo_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B0007DF7WQ?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2603339) | 4.58 | 36
+3-C-13 | _I Go Pogo_ | Walt Kelly, Sam Sloan (Introduction) | [Amazon](https://www.amazon.com/dp/4871876802?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652165) | 4.55 | 142
+3-C-27 | _The Complete Peanuts 1959 to 1962_ | Charles M. Schulz | [Amazon](https://www.amazon.com/dp/1560977744?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/54584) | 4.55 | 323
+3-B-11 | _Chaplin: Genius of the Cinema_ | Jeffrey Vance_ | [Amazon](https://www.amazon.com/dp/0810945320?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/84043) | 4.54 | 46
+3-C-18 | _G. O. Fizzickle Pogo_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B0007DF7EO?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1321967) | 4.54 | 46
+3-C-31 | _The New Annotated Sherlock Holmes Volume 1_ | Sir Arthur Conan Doyle_ | [Amazon](https://www.amazon.com/dp/B000UV57PM?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/436268) | 4.54 | 1088
+4-B-18 | _Open Source (Enhancement Series) (Volume 1)_ | Anna L. Davis | [Amazon](https://www.amazon.com/dp/099678280X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/27093935) | 4.52 | 22
+2-E-21 | _Twentieth Century's Fox: Darryl F. Zanuck And The Culture Of Hollywood_ | George F. Custen_ | [Amazon](https://www.amazon.com/dp/046507619X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/956491) | 4.50 | 2
+3-D-15 | _Keith Tyson: Geno Pheno_ | Keith Tyson | [Amazon](https://www.amazon.com/dp/1930743505?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2949106) | 4.50 | 2
+7-A-20 | _Optical Network Design and Planning (Optical Networks_ | Jane M. Simmons | [Amazon](https://www.amazon.com/dp/3319330977?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5677275) | 4.50 | 1
+8-C-2 | _Passages to Freedom: A Story of Capture and Escape_ | Joseph Frelinghuysen | [Amazon](https://www.amazon.com/dp/0897451317?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2225587) | 4.50 | 4
+4-B-3 | _The Elements of Computing Systems_ | Noam Nisan, Shimon Schocken | [Amazon](https://www.amazon.com/dp/0262640686?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/910789) | 4.49 | 272
+5-A-3 | _The Art of Computer Programming, Vol. 1: Fundamental Algorithms_ | Donald E. Knuth | [Amazon](https://www.amazon.com/dp/0201896834?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/112239) | 4.49 | 668
+5-A-4 | _Art of Computer Programming, Volume 2: Seminumerical Algorithms_ | Donald E. Knuth |  \| [Goodreads](https://www.goodreads.com/book/show/112239) | 4.49 | 668
+5-A-5 | _The Art of Computer Programming: Volume 3: Sorting and Searching_ | Donald E. Knuth | [Amazon](https://www.amazon.com/dp/0201896850?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/112239) | 4.49 | 668
+6-B-26 | _Taradonovan_ | Tara Donovan, Lawrence Weschler | [Amazon](https://www.amazon.com/dp/1580932134?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3766965) | 4.48 | 23
+3-C-17 | _Potluck Pogo_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B00470IQXW?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1836691) | 4.47 | 3
+3-C-2 | _Pogo: Prisoner of Love_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B0006C2O42?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652156) | 4.46 | 50
+3-C-9 | _The Pogo Sunday book_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B0007DF7MQ?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/697978) | 4.46 | 35
+1-B-7 | _Press Here_ | Herve Tullet | [Amazon](https://www.amazon.com/dp/0811879542?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/9677870) | 4.44 | 16523
+3-A-21 | _DisneyWar_ | James B. Stewart | [Amazon](https://www.amazon.com/dp/0743267095?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/36219721) | 4.44 | 9
+7-D-13 | _The Creative Digital Darkroom_ | Katrin Eismann,  Sean Duggan | [Amazon](https://www.amazon.com/dp/0596100477?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1284735) | 4.44 | 59
+2-A-11 | _The Parade's Gone By._ | Kevin Brownlow | [Amazon](https://www.amazon.com/dp/B00L5O81QK?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/22798509) | 4.43 | 1
+2-A-12 | _The Parade's Gone By._ | Kevin Brownlow | [Amazon](https://www.amazon.com/dp/0520030680?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/931166) | 4.43 | 486
+3-C-3 | _Gone Pogo_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B000CQRBLI?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/697955) | 4.42 | 37
+3-E-31 | _Elements: A Visual Exploration of Every Known Atom in the Universe_ | Theodore Gray,  Nick Mann | [Amazon](https://www.amazon.com/dp/1579128955?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6678064) | 4.42 | 3192
+7-A-21 | _Memory Systems: Cache, DRAM, Disk_ | Bruce Jacob, David Wang |  \| [Goodreads](https://www.goodreads.com/book/show/1497554) | 4.42 | 12
+2-B-13 | _The Art of Finding Nemo_ | Mark Cotta Vaz, John Lasseter | [Amazon](https://www.amazon.com/dp/0811839753?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/311264) | 4.41 | 973
+3-F-23 | _The Secret of Selling Anything_ | Harry Browne |  \| [Goodreads](https://www.goodreads.com/book/show/17622965) | 4.41 | 76
+8-A-3 | _The Visual Display of Quantitative Information_ | Edward R. Tufte | [Amazon](https://www.amazon.com/dp/096139210X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/17744) | 4.41 | 5652
+1-C-7 | _Sounds In the Air: The Golden Age of Radio_ | Norman Finkelstein | [Amazon](https://www.amazon.com/dp/0595131905?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2313397) | 4.40 | 5
+3-C-7 | _Pogo: We Have Met The Enemy And He Is Us_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/0671212605?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652112) | 4.40 | 196
+8-C-14 | _The Prize: The Epic Quest for Oil, Money, and Power_ | Daniel Yergin | [Amazon](https://www.amazon.com/dp/1439110123?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/169354) | 4.40 | 5440
+2-C-15 | _Irving Thalberg: Boy Wonder to Producer Prince_ | Mark A. Vieira | [Amazon](https://www.amazon.com/dp/0520260481?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6416292) | 4.39 | 89
+2-B-2 | _The Hollywood Studio System: A History_ | Douglas Gomery | [Amazon](https://www.amazon.com/dp/1844570649?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/798092) | 4.38 | 21
+2-F-16 | _John Von Neumann and Norbert Wiener: From Mathematics to the Technologies of Life and Death_ | Steve Joshua Heims | [Amazon](https://www.amazon.com/dp/0262081059?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1378220) | 4.38 | 1
+3-C-21 | _The Pogo Poop Book_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B001MSGXTQ?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/9410907) | 4.38 | 16
+3-F-31 | _The Valley of Heart's Delight: A Silicon Valley Notebook 1963 - 2001_ | Michael S. Malone | [Amazon](https://www.amazon.com/dp/047120191X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/507027) | 4.38 | 8
+4-F-32 | _The Valley of Heart's Delight: A Silicon Valley Notebook 1963 - 2001_ | Michael S. Malone | [Amazon](https://www.amazon.com/dp/047120191X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/507027) | 4.38 | 8
+2-B-24 | _To Infinity and Beyond!: The Story of Pixar Animation Studios_ | Karen Paik | [Amazon](https://www.amazon.com/dp/0811850129?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1060018) | 4.37 | 416
+3-C-15 | _The Pogo Party_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B0007DF7J4?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2603315) | 4.37 | 30
+3-C-23 | _Krazy Kat: The Comic Art of George Herriman_ | Patrick McDonnell, Karen O'Connell | [Amazon](https://www.amazon.com/dp/0810981521?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/311037) | 4.37 | 655
+5-D-30 | _Fools Rush in Where Monkeys Fear to Tread: Taking Aim at Everyone_ | Carl R. Trueman | [Amazon](https://www.amazon.com/dp/1596384050?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13581440) | 4.37 | 138
+1-B-21 | _The Gay Talese Reader_ | GayTalese | [Amazon](https://www.amazon.com/dp/B003N1YKKE?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/9329112) | 4.36 | 0
+1-C-26 | _The Golden Web: A History of Broadcasting in the United States: Vol. 2 - 1933 to 1953_ | Erik Barnouw | [Amazon](https://www.amazon.com/dp/0195004752?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/646145) | 4.36 | 14
+5-D-12 | _Sol LeWitt: 100 Views_ | Susan Cross, Denise Markonish |  \| [Goodreads](https://www.goodreads.com/book/show/6713448) | 4.36 | 22
+1-A-16 | _The Powers That Be_ | David Halberstam | [Amazon](https://www.amazon.com/dp/0252069412?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/75414) | 4.35 | 605
+8-A-16 | _Network Algorithmics: An Interdisciplinary Approach to Designing Fast Networked Devices_ | George Varghese |  \| [Goodreads](https://www.goodreads.com/book/show/475103) | 4.35 | 16
+2-B-14 | _Core Memory: A Visual Survey of Vintage Computers_ | John Alderman,  Mark Richards | [Amazon](https://www.amazon.com/dp/0811854426?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/784082) | 4.34 | 77
+4-A-26 | _Metaprogramming Ruby: Program Like the Ruby Pros_ | Metaprogramming Ruby: Program Like the Ruby Pros | [Amazon](https://www.amazon.com/dp/1934356476?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7183279) | 4.34 | 628
+4-D-1 | _The Algorithm Design Manual_ | Steve S. Skiena | [Amazon](https://www.amazon.com/dp/0387948600?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/425208) | 4.34 | 1280
+8-B-27 | _Hollywood Dreams Made Real: Irving Thalberg and the Rise of M-G-M_ | Mark A. Vieira | [Amazon](https://www.amazon.com/dp/0810972344?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3423531) | 4.34 | 50
+1-C-6 | _A History of Mass Communication: Six Information Revolutions_ | Irving Fang | [Amazon](https://www.amazon.com/dp/0240802543?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3990100) | 4.33 | 11
+3-C-8 | _Pogo's Body Politic_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/067122302X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652142) | 4.33 | 12
+3-E-14 | _IBM's 360 and Early 370 Systems_ | Emerson W. Pugh,  Lyle R. Johnson,  John H. Palmer | [Amazon](https://www.amazon.com/dp/0262161230?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1454218) | 4.33 | 10
+4-A-10 | _The Origins of Digital Computers: Selected Papers (Texts and Monographs in Computer Science)_ | B. Randell | [Amazon](https://www.amazon.com/dp/3540113193?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4190446) | 4.33 | 3
+4-A-25 | _Black Berry Develomrnt_ | Anwar Ludin | [Amazon](https://www.amazon.com/dp/1430261579?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/22021402) | 4.33 | 3
+4-B-8 | _Alan Turing: Life and Legacy of a Great Thinker_ | Christof Teuscher |  \| [Goodreads](https://www.goodreads.com/book/show/150735) | 4.33 | 3
+4-D-27 | _Paradigms of Artificial Intelligence Programming_ | Peter Norvig | [Amazon](https://www.amazon.com/dp/1558601910?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/83884) | 4.33 | 399
+5-E-18 | _Cable Cowboy: John Malone and the Rise of the Modern Cable Business_ | Mark Robichaux | [Amazon](https://www.amazon.com/dp/047170637X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/679418) | 4.33 | 311
+8-D-9 | _Wizard of Menlo Park, New Jersey_ | Carol Lynch Williams,  Cheri Pray Earl,  Manelle Oliphant | [Amazon](https://www.amazon.com/dp/1938301773?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18596318) | 4.33 | 6
+1-D-16 | _The Box: An Oral History of Television, 1929-1961_ | Jeff Kisseloff | [Amazon](https://www.amazon.com/dp/0140252657?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1552038) | 4.32 | 24
+3-C-1 | _Pogo Revisited: Instant Pogo / The Jack Acid Society Black Book / The Pogo Poop Book_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/0671217720?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652119) | 4.32 | 41
+3-C-14 | _Pogo's Bats and the Belles Free_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/0671223933?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652152) | 4.32 | 22
+2-D-8 | _Who the Devil Made It: Conversations with Legendary Film Directors_ | Peter Bogdanovich | [Amazon](https://www.amazon.com/dp/0345404572?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/929602) | 4.31 | 274
+2-E-3 | _Seagalogy: A Study of the Ass-Kicking Films of Steven Seagal_ | Vern | [Amazon](https://www.amazon.com/dp/1845769279?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2341304) | 4.31 | 210
+3-C-5 | _Pogo: Romances Recaptured_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/0671221841?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/652104) | 4.31 | 59
+4-E-4 | _The Pragmatic Programmer: From Journeyman to Master_ | Andy Hunt, Dave Thomas | [Amazon](https://www.amazon.com/dp/020161622X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4099) | 4.31 | 10018
+5-A-13 | _Concrete Mathematics: A Foundation for Computer Science_ | Concrete Mathematics: A Foundation for Computer Science | [Amazon](https://www.amazon.com/dp/0201142368?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/112243) | 4.31 | 1491
+7-B-26 | _iOS Programming: The Big Nerd Ranch Guide (5th Edition) (Big Nerd Ranch Guides)_ | Christian Keur | [Amazon](https://www.amazon.com/dp/0134390733?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/28241611) | 4.31 | 42
+8-D-29 | _The Nikola Tesla Treasury_ | Nikola Tesla |  \| [Goodreads](https://www.goodreads.com/book/show/1783518) | 4.31 | 24
+4-D-10 | _Applied Java Patterns_ | Stephen A. Stelting |  \| [Goodreads](https://www.goodreads.com/book/show/1902734) | 4.29 | 12
+4-E-30 | _The General Managers_ | John P. Kotter | [Amazon](https://www.amazon.com/dp/0029180007?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1601848) | 4.29 | 13
+5-E-26 | _The Maverick and His Machine: Thomas Watson, Sr. and the Making of IBM_ | Kevin Maney | [Amazon](https://www.amazon.com/dp/0471414638?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/16769529) | 4.29 | 17
+8-A-2 | _Visual Explanations: Images and Quantities, Evidence and Narrative_ | Edward R. Tufte | [Amazon](https://www.amazon.com/dp/0961392126?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/17746) | 4.29 | 2447
+7-C-15 | _Advanced Mac OS X Programming: The Big Nerd Ranch Guide (Big Nerd Ranch Guides)_ | Mark Dalrymple | [Amazon](https://www.amazon.com/dp/0321706250?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8635915) | 4.28 | 25
+1-C-22 | _The Murrow Boys: Pioneers on the Front Lines of Broadcast Journalism_ | Stanley W. Cloud | [Amazon](https://www.amazon.com/dp/0395680840?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1043745) | 4.27 | 221
+2-C-20 | _This Is Orson Welles by Orson Welles_ | Orson Welles_ | [Amazon](https://www.amazon.com/dp/B01N1ESZGW?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/117093) | 4.27 | 710
+2-C-21 | _A Talent For Trouble: The Life Of Hollywood's Most Acclaimed Director, William Wyler_ | Jan Herman | [Amazon](https://www.amazon.com/dp/030680798X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1496210) | 4.27 | 28
+1-D-22 | _Cecil B. DeMille's Hollywood_ | Robert S. Birchard |  \| [Goodreads](https://www.goodreads.com/book/show/539354) | 4.26 | 19
+2-C-2 | _Cecil B. DeMille's Hollywood_ | Robert S. Birchard | [Amazon](https://www.amazon.com/dp/0813123240?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/539354) | 4.26 | 19
+2-C-25 | _The Genius of the System: Hollywood Filmmaking in the Studio Era_ | Thomas Schatz |  \| [Goodreads](https://www.goodreads.com/book/show/101447) | 4.26 | 251
+7-C-14 | _Mac OS X Internals: A Systems Approach (paperback)_ | Amit Singh | [Amazon](https://www.amazon.com/dp/0134426541?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/169025) | 4.26 | 95
+4-B-5 | _Quantum Information: An Overview_ | Gregg Jaeger |  \| [Goodreads](https://www.goodreads.com/book/show/416602) | 4.25 | 3
+5-C-23 | _Modeling and Reasoning with Bayesian Networks_ | Adnan Darwiche | [Amazon](https://www.amazon.com/dp/0521884381?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8285949) | 4.25 | 16
+7-A-14 | _Not All Those Who Wander Are Lost_ | Steve Blank | [Amazon](https://www.amazon.com/dp/0976470748?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7762706) | 4.25 | 20
+2-E-11 | _Michael Caine - Acting in Film: An Actor's Take on Movie Making_ | Michael Caine | [Amazon](https://www.amazon.com/dp/1557832773?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/776196) | 4.24 | 751
+3-C-6 | _Impollutable Pogo_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/0671207377?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1269537) | 4.24 | 83
+3-D-11 | _Agile Software Development, Principles, Patterns, and Practices_ | Robert C. Martin | [Amazon](https://www.amazon.com/dp/0135974445?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/84985) | 4.24 | 921
+3-D-18 | _The Little Kingdom: The Private Story of Apple Computer_ | Michael Moritz | [Amazon](https://www.amazon.com/dp/0688039731?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/224489) | 4.24 | 50
+4-C-9 | _Head First Design Patterns: A Brain-Friendly Guide_ | Eric Freeman, Kathy Sierra, Bert Bates, Elisabeth Robson | [Amazon](https://www.amazon.com/dp/B00CVDPQAS?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/58128) | 4.24 | 4925
+4-E-5 | _Agile Software Development, Principles, Patterns, and Practices_ | Robert C. Martin | [Amazon](https://www.amazon.com/dp/0135974445?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/84985) | 4.24 | 921
+4-E-27 | _Don't Make Me Think, Revisited: A Common Sense Approach to Web Usability (3rd Edition) (Voices That Matter)_ | Steve Krug | [Amazon](https://www.amazon.com/dp/0321965515?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18197267) | 4.24 | 4724
+1-D-28 | _Digital Apollo: Human and Machine in Spaceflight_ | David A. Mindell |  \| [Goodreads](https://www.goodreads.com/book/show/2422710) | 4.23 | 275
+2-A-13 | _CIty of Nets: A Portrait of Hollywood in the 1940's_ | Otto Friedrich | [Amazon](https://www.amazon.com/dp/006232604X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/21120599) | 4.23 | 23
+2-A-14 | _CIty of Nets: A Portrait of Hollywood in the 1940's_ | Otto Friedrich | [Amazon](https://www.amazon.com/dp/006232604X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/21120599) | 4.23 | 23
+3-A-12 | _Citizen Turner_ | Robert Goldberg_&_Gerald Jay Goldberg_ | [Amazon](https://www.amazon.com/dp/0151180083?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1452292) | 4.23 | 13
+3-B-14 | _W.C. Fields_ | James Curtis | [Amazon](https://www.amazon.com/dp/0375402179?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1769962) | 4.23 | 86
+3-E-9 | _One on One with Andy Grove_ | Andrew Grove | [Amazon](https://www.amazon.com/dp/0399132503?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1357179) | 4.23 | 22
+1-D-1 | _Tube: The Invention of Television (Sloan Technology Series)_ | David E. Fisher,  Marshall Jon Fish | [Amazon](https://www.amazon.com/dp/1887178171?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1527868) | 4.22 | 22
+1-D-2 | _Tube: The Invention of Television (Sloan Technology Series)_ | David E. Fisher,  Marshall Jon Fish | [Amazon](https://www.amazon.com/dp/1887178171?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1527868) | 4.22 | 22
+2-D-19 | _The DV Rebel's Guide: An All-Digital Approach to Making Killer Action Movies on the Cheap_ | Stu Maschwitz | [Amazon](https://www.amazon.com/dp/0321413644?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/43164) | 4.22 | 208
+3-E-8 | _The Man Behind the Microchip: Robert Noyce and the Invention of Silicon Valley_ | Leslie Berlin | [Amazon](https://www.amazon.com/dp/B01JXUHQFO?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1203093) | 4.22 | 175
+4-C-16 | _Refactoring: Improving the Design of Existing Code_ | Martin Fowler, Kent Beck, John Brant, William Opdyke, Don Roberts | [Amazon](https://www.amazon.com/dp/0201485672?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/44936) | 4.22 | 5109
+8-E-23 | _The 2014 Internet Peering Playbook: Connecting to the Core of the Internet_ | William B. Norton | [Amazon](https://www.amazon.com/dp/1937451119?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/20447919) | 4.22 | 32
+2-C-9 | _Orson Welles: Volume 2: Hello Americans_ | Simon Callow | [Amazon](https://www.amazon.com/dp/0670872563?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/117091) | 4.21 | 170
+8-A-15 | _The Illustrated Network, Second Edition: How TCP/IP Works in a Modern Network_ | Walter Goralski | [Amazon](https://www.amazon.com/dp/0128110279?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/34884536) | 4.21 | 0
+2-A-19 | _The Speed of Sound: Hollywood and the Talkie Revolution 1926-1930_ | Scott Eyman | [Amazon](https://www.amazon.com/dp/1501103830?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1200704) | 4.20 | 89
+2-D-10 | _Pictures at a Revolution: Five Movies and the Birth of the New Hollywood_ | Mark Harris | [Amazon](https://www.amazon.com/dp/0143115030?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2092154) | 4.20 | 2325
+3-F-12 | _On the Edge: the Spectacular Rise and Fall of Commodore_ | Brian Bagnall | [Amazon](https://www.amazon.com/dp/0973864907?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/412006) | 4.20 | 402
+2-B-5 | _Power to Burn: Michael Ovitz and the New Business of Show Business_ | Stephen Singular | [Amazon](https://www.amazon.com/dp/1559723351?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/932607) | 4.19 | 37
+3-B-21 | _Charles Chaplin: My Autobiography_ | Charles Chaplin_ | [Amazon](https://www.amazon.com/dp/B01K0TF0PU?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/84038) | 4.19 | 2307
+3-D-12 | _Revolution in The Valley: The Insanely Great Story of How the Mac Was Made_ | Andy Hertzfeld | [Amazon](https://www.amazon.com/dp/0596007191?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/40492) | 4.19 | 1350
+3-E-30 | _The Codebreakers: The Comprehensive History of Secret Communication from Ancient Times to the Internet_ | David Kahn | [Amazon](https://www.amazon.com/dp/0684831309?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/29608) | 4.19 | 1104
+4-A-31 | _Digital Retro_ | Gordon Laing | [Amazon](https://www.amazon.com/dp/1904705391?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1265714) | 4.19 | 26
+5-D-4 | _Introduction to the Theory of Computation_ | Michael Sipser | [Amazon](https://www.amazon.com/dp/0534950973?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/400716) | 4.19 | 1187
+3-C-30 | _Distributed Algorithms(The Morgan Kaufmann Series in Data Management Systems)_ | Nancy A. Lynch | [Amazon](https://www.amazon.com/dp/1558603484?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/425215) | 4.18 | 37
+3-E-11 | _A Few Good Men From Univac (History of Computing)_ | David E. Lundstrom | [Amazon](https://www.amazon.com/dp/0262620758?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2086164) | 4.18 | 2
+4-B-4 | _Processing: A Programming Handbook for Visual Designers and Artists_ | Casey Reas, Ben Fry, | [Amazon](https://www.amazon.com/dp/0262182629?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/472325) | 4.18 | 302
+4-F-19 | _Fortune's Formula: The Untold Story of the Scientific Betting System That Beat the Casinos and Wall Street_ | William Poundstone | [Amazon](https://www.amazon.com/dp/0809045990?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/186124) | 4.18 | 2136
+2-C-12 | _What Ever Happened to Orson Welles?: A Portrait of an Independent Career_ | Joseph McBride | [Amazon](https://www.amazon.com/dp/0813124107?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/117092) | 4.17 | 43
+3-E-3 | _Engines of Creation: The Coming Era of Nanotechnology_ | Eric Drexler | [Amazon](https://www.amazon.com/dp/0385199732?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/83596) | 4.17 | 650
+3-E-27 | _Supercade: A Visual History of the Videogame Age 1971-1984_ | Van Burnham | [Amazon](https://www.amazon.com/dp/0262024926?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1489983) | 4.17 | 112
+4-A-28 | _The Definitive Guide to CentOS_ | Peter Membrey, Tim Verhoeven, Ralph Angenendt |  \| [Goodreads](https://www.goodreads.com/book/show/6666395) | 4.17 | 15
+4-B-10 | _Computer Organization and Design: The Hardware/Software Interface. Third Edition, Revised_ | David A. Patterson, John L. Hennessy | [Amazon](https://www.amazon.com/dp/0123706068?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/19285723) | 4.17 | 12
+4-B-26 | _Between Silk and Cyanide: A Codemaker's War, 1941-1945_ | Leo Marks | [Amazon](https://www.amazon.com/dp/068486780X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/557743) | 4.17 | 1403
+4-C-20 | _Object-Oriented Design Heuristics_ | Arthur J. Riel | [Amazon](https://www.amazon.com/dp/020163385X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/179206) | 4.17 | 70
+4-D-17 | _Design Patterns in Ruby_ | Russ Olsen |  \| [Goodreads](https://www.goodreads.com/book/show/2278064) | 4.17 | 561
+7-C-16 | _Objective-C Programming: The Big Nerd Ranch Guide (2nd Edition) (Big Nerd Ranch Guides)_ | Aaron Hillegass, Mikey Ward | [Amazon](https://www.amazon.com/dp/032194206X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/9496558) | 4.17 | 388
+2-B-17 | _Theory of Games and Economic Behavior_ | John von Neumann, Oskar Morgenstern | [Amazon](https://www.amazon.com/dp/0691130612?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/483055) | 4.16 | 178
+2-C-5 | _The Name above the Title: An Autobiography_ | Frank Capra, Jeanine Basinger,  John Ford | [Amazon](https://www.amazon.com/dp/0306807718?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/96569) | 4.16 | 329
+4-D-16 | _Design Patterns: Elements of Reusable Object-Oriented Software_ | Erich Gamma, Ralph Johnson, John Vlissides, Richard Helm |  \| [Goodreads](https://www.goodreads.com/book/show/85009) | 4.16 | 7319
+4-D-29 | _The Essential Turing: Seminal Writings in Computing, Logic, Philosophy, Artificial Intelligence, and Artificial Life plus The Secrets of Enigma_ | Alan M. Turing,  B. Jack Copeland | [Amazon](https://www.amazon.com/dp/0198250797?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/150734) | 4.16 | 84
+5-A-2 | _The Universal Computer_ | Martin Davis | [Amazon](https://www.amazon.com/dp/0393047857?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/299652) | 4.16 | 132
+5-C-21 | _The Deal of the Century: The Breakup of AT&T (A touchstone book)_ | Steve Coll | [Amazon](https://www.amazon.com/dp/0671645927?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/199958) | 4.16 | 62
+1-D-10 | _Please Stand By: A Prehistory of Television_ | Michael Ritchie | [Amazon](https://www.amazon.com/dp/0879515465?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1840244) | 4.15 | 13
+2-A-9 | _River of Shadows: Eadweard Muybridge and the Technological Wild West_ | Rebecca Solnit | [Amazon](https://www.amazon.com/dp/0142004103?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/28054) | 4.15 | 943
+2-A-10 | _River of Shadows: Eadweard Muybridge and the Technological Wild West_ | Rebecca Solnit | [Amazon](https://www.amazon.com/dp/B01181TD48?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1437732) | 4.15 | 37
+2-A-20 | _Hollywood Remembered: An Oral History of Its Golden Age_ | Paul Zollo | [Amazon](https://www.amazon.com/dp/B010DT72RQ?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1365836) | 4.15 | 4
+2-A-26 | _Hollywood Remembered: An Oral History of Its Golden Age_ | Paul Zollo | [Amazon](https://www.amazon.com/dp/B010DT72RQ?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1365836) | 4.15 | 4
+2-F-25 | _Hackers: Heroes of the Computer Revolution_ | Steven Levy | [Amazon](https://www.amazon.com/dp/1449388396?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8260364) | 4.15 | 317
+3-C-32 | _The New Annotated Sherlock Holmes Volume 2_ | Leslie S., Editor Klinger_ | [Amazon](https://www.amazon.com/dp/B008SCBEIY?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/436269) | 4.15 | 8
+4-E-18 | _Peopleware: Productive Projects and Teams_ | Tom DeMarco, Timothy Lister | [Amazon](https://www.amazon.com/dp/0932633439?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/67825) | 4.15 | 5335
+5-B-29 | _Speech and Language Processing, 2nd Edition_ | Daniel Jurafsky,  James H. Martin | [Amazon](https://www.amazon.com/dp/0131873210?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/908048) | 4.15 | 94
+1-B-10 | _Walter Lippmann and the American Century_ | Ronald Steel | [Amazon](https://www.amazon.com/dp/0316811904?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1585134) | 4.14 | 10
+1-B-23 | _However Long the Night: Molly Melching's Journey to Help Millions of African Women and Girls Triumph_ | Aimee Molloy | [Amazon](https://www.amazon.com/dp/0062132792?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/15818473) | 4.14 | 625
+2-C-8 | _Orson Welles, Volume 1: The Road to Xanadu_ | Simon Callow | [Amazon](https://www.amazon.com/dp/0140254560?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/117094) | 4.14 | 358
+5-E-25 | _High Noon: The Hollywood Blacklist and the Making of an American Classic_ | Glenn Frankel | [Amazon](https://www.amazon.com/dp/1620409488?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/30038933) | 4.14 | 268
+7-B-10 | _Unix Power Tools, Third Edition_ | Shelley Powers,  Jerry Peek,  Tim O'Reilly | [Amazon](https://www.amazon.com/dp/0596003307?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/172314) | 4.14 | 420
+8-A-22 | _What is Life?: How Chemistry Becomes Biology Reprint edition by Pross, Addy (2014) Paperback_ | Addy Pross | [Amazon](https://www.amazon.com/dp/B010WERABU?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/162780) | 4.14 | 2911
+4-C-23 | _Patterns of Enterprise Application Architecture_ | Martin Fowler | [Amazon](https://www.amazon.com/dp/0321127420?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/70156) | 4.13 | 2526
+4-E-26 | _On Intelligence: How a New Understanding of the Brain Will Lead to the Creation of Truly Intelligent Machines_ | Jeff Hawkins, Sandra Blakeslee | [Amazon](https://www.amazon.com/dp/0805078533?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/27539) | 4.13 | 4310
+5-E-2 | _Dealers of Lightning: Xerox PARC and the Dawn of the Computer Age_ | Michael A. Hiltzik | [Amazon](https://www.amazon.com/dp/0887309895?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1101290) | 4.13 | 1098
+5-F-4 | _The Quantum Doctor: A Physicist's Guide to Health and Healing_ | Goswami, Amit | [Amazon](https://www.amazon.com/dp/B015QKXK14?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/670169) | 4.13 | 99
+8-A-4 | _Beautiful Evidence_ | Edward R. Tufte | [Amazon](https://www.amazon.com/dp/0961392177?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/17743) | 4.13 | 1840
+8-A-5 | _Artificial Intelligence: A Modern Approach (2nd Edition)_ | Stuart Russell, Peter Norvig | [Amazon](https://www.amazon.com/dp/0137903952?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/27543) | 4.13 | 2288
+1-A-10 | _Perfecting Sound Forever: An Aural History of Recorded Music_ | Greg Milner | [Amazon](https://www.amazon.com/dp/0571211658?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18906430) | 4.12 | 19
+1-D-4 | _The Last Lone Inventor: A Tale of Genius, Deceit, and the Birth of Television_ | Evan I. Schwartz | [Amazon](https://www.amazon.com/dp/0060935596?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1127305) | 4.12 | 56
+2-C-27 | _Mencken: The American Iconoclast_ | Marion Elizabeth Rodgers | [Amazon](https://www.amazon.com/dp/0195072383?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/300844) | 4.12 | 112
+4-B-13 | _Free Software, Free Society: Selected Essays_ | Richard M. Stallman, Lawrence Lessig, Joshua Gay | [Amazon](https://www.amazon.com/dp/1882114981?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/942560) | 4.12 | 270
+5-B-8 | _Information Theory: A Tutorial Introduction_ | James V. Stone | [Amazon](https://www.amazon.com/dp/099336795X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/23057894) | 4.12 | 34
+8-E-16 | _Memoirs_ | Jean Monnet | [Amazon](https://www.amazon.com/dp/0385125054?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1680001) | 4.12 | 25
+2-A-5 | _The Dead Hand: The Untold Story of the Cold War Arms Race and Its Dangerous Legacy_ | David Hoffman | [Amazon](https://www.amazon.com/dp/0307387844?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6623920) | 4.11 | 2444
+2-C-4 | _Pickford: The Woman Who Made Hollywood_ | Eileen Whitfield | [Amazon](https://www.amazon.com/dp/0813191793?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1061990) | 4.11 | 204
+2-E-16 | _Lion of Hollywood: The Life and Legend of Louis B. Mayer_ | Scott Eyman | [Amazon](https://www.amazon.com/dp/0743204816?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/841442) | 4.11 | 198
+2-F-5 | _The Dream: How I Learned the Risks and Rewards of Entrepreneurship and Made Millions_ | Gurbaksh Chahal | [Amazon](https://www.amazon.com/dp/0230610951?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5585856) | 4.11 | 316
+2-F-24 | _Dark Hero of the Information Age: In Search Of Norbert Wiener--Father of Cybernetics_ | Flo Conway, Jim Siegelman | [Amazon](https://www.amazon.com/dp/0738203688?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/211053) | 4.11 | 52
+3-B-6 | _The Vintage Mencken_ | H. L. Mencken | [Amazon](https://www.amazon.com/dp/0679728953?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/300842) | 4.11 | 543
+8-E-1 | _Start-up Nation: The Story of Israel's Economic Miracle_ | Dan Senor, Saul Singer | [Amazon](https://www.amazon.com/dp/0446541478?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6885191) | 4.11 | 4643
+3-D-19 | _Father, Son & Co.: My Life at IBM and Beyond_ | Thomas J. Watson, Jr. and Peter Peter | [Amazon](https://www.amazon.com/dp/B0010AGWEM?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/245112) | 4.10 | 227
+4-B-22 | _They Can Kill You... But They Can't Eat You: Lessons from the Front_ | Dawn Steel | [Amazon](https://www.amazon.com/dp/0671738321?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1367651) | 4.10 | 6
+4-C-26 | _Joel on Software_ | Joel Spolsky |  \| [Goodreads](https://www.goodreads.com/book/show/41786) | 4.10 | 2624
+4-D-14 | _Web Form Design: Filling in the Blanks_ | Luke Wroblewski | [Amazon](https://www.amazon.com/dp/B00DEKSE3S?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3296910) | 4.10 | 1679
+5-B-6 | _Elements of Information Theory (Wiley Series in Telecommunications and Signal Processing)_ | Thomas M. Cover,  Joy A. Thomas | [Amazon](https://www.amazon.com/dp/0471062596?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/433439) | 4.10 | 169
+7-D-12 | _Mastering Windows Server 2003_ | Mark Minasi,  Christa Anderson, Michele Beverridge, C. A. Callahan, | [Amazon](https://www.amazon.com/dp/0782141307?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/48592) | 4.10 | 69
+2-B-7 | _Silent Stars_ | Jeanine Basinger | [Amazon](https://www.amazon.com/dp/0819564516?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/609349) | 4.09 | 263
+3-A-23 | _Droidmaker: George Lucas and the Digital Revolution_ | Michael Rubin | [Amazon](https://www.amazon.com/dp/0937404675?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/294821) | 4.09 | 108
+5-D-8 | _Microcosm: The Quantum Revolution In Economics And Technology_ | George Gilder | [Amazon](https://www.amazon.com/dp/067170592X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/83794) | 4.09 | 31
+5-D-9 | _Computer Architecture: A Quantitative Approach, 3rd Edition_ | John L. Hennessy, David A. Patterson | [Amazon](https://www.amazon.com/dp/1558605967?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/83794) | 4.09 | 31
+5-D-10 | _Computer Architecture: A Quantitative Approach, 3rd Edition_ | John L. Hennessy, David A. Patterson | [Amazon](https://www.amazon.com/dp/1558605967?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/83794) | 4.09 | 31
+5-D-21 | _Game Over: How Nintendo Zapped an American Industry, Captured Your Dollars, and Enslaved Your Children_ | David Sheff | [Amazon](https://www.amazon.com/dp/0679404694?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/339583) | 4.09 | 54
+7-E-6 | _Using csh & tcsh (Nutshell Handbooks)_ | Paul DuBois | [Amazon](https://www.amazon.com/dp/1565921321?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/605997) | 4.09 | 23
+8-E-13 | _Sam Walton, Made in America My Story_ | Sam & Huey, John Walton | [Amazon](https://www.amazon.com/dp/0345538447?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10631) | 4.09 | 10263
+1-A-24 | _Bill & Dave: How Hewlett and Packard Built the World's Greatest Company_ | Michael S. Malone | [Amazon](https://www.amazon.com/dp/1591841526?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/250898) | 4.08 | 115
+2-B-9 | _The Star Machine_ | Jeanine Basinger | [Amazon](https://www.amazon.com/dp/0307388751?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/708947) | 4.08 | 404
+3-F-20 | _Racing the Beam: The Atari Video Computer System (Platform Studies)_ | Nick Montfort,  Ian Bogost | [Amazon](https://www.amazon.com/dp/026201257X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5435210) | 4.08 | 458
+4-B-1 | _Inside the Machine: An Illustrated Introduction to Microprocessors and Computer Architecture_ | Jon Stokes | [Amazon](https://www.amazon.com/dp/1593271042?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/610830) | 4.08 | 111
+1-D-3 | _The Boy Genius and the Mogul: The Untold Story of Television_ | Daniel Stashower | [Amazon](https://www.amazon.com/dp/0767907590?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/133628) | 4.07 | 39
+2-E-17 | _The Art of Alfred Hitchcock: Fifty Years of His Motion Pictures_ | Donald Spoto | [Amazon](https://www.amazon.com/dp/0385418132?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/15075) | 4.07 | 434
+3-F-1 | _Infinite Loop : How the World's Most Insanely Great Computer Company W_ | Michael S. Malone | [Amazon](https://www.amazon.com/dp/B002K7U9EI?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/15244215) | 4.07 | 2
+4-E-8 | _ERLANG Programming_ | Francesco Cesarini, Simon Thompson |  \| [Goodreads](https://www.goodreads.com/book/show/4826120) | 4.07 | 175
+5-C-13 | _Compilers: Principles, Techniques, and Tools 2nd By Alfred V. Aho (International Economy Edition)_ | Alfred V Aho | [Amazon](https://www.amazon.com/dp/9332518661?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/25860573) | 4.07 | 3
+6-E-35 | _Give and Take: Why Helping Others Drives Our Success_ | Adam M. Grant Ph.D. | [Amazon](https://www.amazon.com/dp/B00AFPTSI0?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/16158498) | 4.07 | 11381
+8-A-21 | _When I Stop Talking, You'll Know I'm Dead: Useful Stories from a Persuasive Man_ | Jerry Weintraub | [Amazon](https://www.amazon.com/dp/0446548162?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7720207) | 4.07 | 2147
+8-D-26 | _The Power Makers: Steam, Electricity, and the Men Who Invented Modern America_ | Maury Klein | [Amazon](https://www.amazon.com/dp/1596914122?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2969554) | 4.06 | 68
+3-B-24 | _The Essential Chaplin: Perspectives on the Life and Art of the Great Comedian__ | Richard Schickel | [Amazon](https://www.amazon.com/dp/1566637015?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/84040) | 4.05 | 19
+3-D-7 | _Hard Drive: Bill Gates and the Making of the Microsoft Empire_ | James Wallace, _Jim Erickson_ | [Amazon](https://www.amazon.com/dp/0887306292?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/41611) | 4.05 | 933
+4-D-18 | _The Mythical Man-Month_ | Frederick P. Brooks Jr. | [Amazon](https://www.amazon.com/dp/0201835959?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13629) | 4.05 | 7638
+5-C-20 | _The Control Revolution: Technological and Economic Origins of the Information Society_ | James Beniger | [Amazon](https://www.amazon.com/dp/0674169859?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/945995) | 4.05 | 58
+1-C-19 | _Treadmill to Oblivion_ | Fred Allen | [Amazon](https://www.amazon.com/dp/1434454126?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2580535) | 4.04 | 30
+2-C-6 | _Marlene Dietrich: Life and Legend_ | Steven Bach | [Amazon](https://www.amazon.com/dp/0816675848?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/11064852) | 4.04 | 8
+3-E-20 | _The Supermen: The Story of Seymour Cray and the Technical Wizards Behind the Supercomputer_ | Charles J. Murray | [Amazon](https://www.amazon.com/dp/B017YCN4IG?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/116196) | 4.04 | 95
+4-D-28 | _Live From New York: An Uncensored History of Saturday Night Live_ | Tom Shales, James Andrew Miller | [Amazon](https://www.amazon.com/dp/0316735655?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/55095) | 4.04 | 10484
+4-E-19 | _Entertainment Industry Economics (5th Edition Guide to Financial Analysis) / Information and Communication series of textbooks in English original series_ | HaroidL Vogei | [Amazon](https://www.amazon.com/dp/7302054169?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1237009) | 4.04 | 40
+4-F-7 | _Extreme Programming Explained: Embrace Change, 2nd Edition (The XP Series)_ | Kent Beck, Cynthia Andres | [Amazon](https://www.amazon.com/dp/0321278658?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/67833) | 4.04 | 2062
+7-B-6 | _Classic Shell Scripting_ | Arnold Robbins | [Amazon](https://www.amazon.com/dp/0596005954?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/299533) | 4.04 | 186
+7-B-21 | _Understanding the Linux Kernel, Third Edition_ | Daniel P. Bovet, Marco Cesati | [Amazon](https://www.amazon.com/dp/0596005652?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/227119) | 4.04 | 447
+8-C-8 | _Spreading the News: The American Postal System from Franklin to Morse_ | Richard R. John | [Amazon](https://www.amazon.com/dp/0674833384?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/603941) | 4.04 | 27
+2-E-18 | _Renegades Write the Rules: How the Digital Royalty Use Social Media to Innovate_ | Amy Jo Martin | [Amazon](https://www.amazon.com/dp/B00CKZBBZG?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13838924) | 4.03 | 119
+4-F-11 | _And Here's the Kicker: Conversations with 21 Top Humor Writers on their Craft_ | Mike Sacks | [Amazon](https://www.amazon.com/dp/1582975051?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6013145) | 4.03 | 1692
+5-D-17 | _More Joel on Software_ | Avram Joel Spolsky | [Amazon](https://www.amazon.com/dp/1430209879?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2718384) | 4.03 | 389
+8-A-23 | _The Xbox 360 Uncloaked:: The Real Story Behind Microsoft's Next-Generation Video Game Console_ | Dean Takahashi | [Amazon](https://www.amazon.com/dp/0977784215?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1342624) | 4.03 | 60
+8-B-4 | _American Steel_ | Richard Preston | [Amazon](https://www.amazon.com/dp/B013J98NQ6?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/22165) | 4.03 | 156
+8-D-25 | _Empires of Light: Edison, Tesla, Westinghouse, and the Race to Electrify the World_ | Jill Jonnes | [Amazon](https://www.amazon.com/dp/0375507396?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/507952) | 4.03 | 1065
+2-C-18 | _I'll Be in My Trailer: The Creative Wars Between Directors and Actors_ | John Badham | [Amazon](https://www.amazon.com/dp/1932907149?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/106794) | 4.02 | 49
+5-C-17 | _Made in Japan: Akio Morita and Sony_ | Akio Morita, Edwin M. Reingold | [Amazon](https://www.amazon.com/dp/0525244654?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1008101) | 4.02 | 2911
+2-E-19 | _Alfred Hitchcock: A Life in Darkness and Light_ | Patrick Mcgilligan | [Amazon](https://www.amazon.com/dp/0060988274?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/447948) | 4.01 | 522
+3-B-9 | _Groucho: The Life and Times of Julius Henry Marx_ | Stefan Kanfer | [Amazon](https://www.amazon.com/dp/0375402187?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/339611) | 4.01 | 476
+3-D-26 | _Battle of Wits by Stephen Budiansky_ | Stephen Budiansky | [Amazon](https://www.amazon.com/dp/0684859327?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/171202) | 4.01 | 218
+4-C-17 | _Refactoring to Patterns_ | Joshua Kerievsky | [Amazon](https://www.amazon.com/dp/0321213351?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/85041) | 4.01 | 1033
+4-D-30 | _Software Estimation: Demystifying the Black Art_ | Steve McConnell |  \| [Goodreads](https://www.goodreads.com/book/show/93891) | 4.01 | 643
+1-A-29 | _Gates: How Microsoft's Mogul Reinvented an Industry--and Made Himself the Richest Man in America_ | Stephen Manes, Paul Andrews | [Amazon](https://www.amazon.com/dp/0671880748?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/41643) | 4.00 | 222
+2-A-29 | _Reinventing the Wheel: A Story of Genius, Innovation, and Grand Ambition_ | Steve Kemper | [Amazon](https://www.amazon.com/dp/0060761385?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/35113379) | 4.00 | 2
+2-C-22 | _Voice Acting For Dummies_ | David Ciccarelli | [Amazon](https://www.amazon.com/dp/1118399587?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/17169570) | 4.00 | 17
+2-F-3 | _Introduction to Quantum Information Science_ | Vlatko Vedral  | [Amazon](https://www.amazon.com/dp/0199673489?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/374285) | 4.00 | 5
+2-F-21 | _The Turing Test: Verbal Behavior as the Hallmark of Intelligence_ | Stuart M. Shieber | [Amazon](https://www.amazon.com/dp/0262692937?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/317209) | 4.00 | 8
+2-F-28 | _Internet Business Models: Text and Cases with Teledesic Case CD-ROM_ | Thomas R. Eisenmann | [Amazon](https://www.amazon.com/dp/0072508345?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8145103) | 4.00 | 1
+3-A-13 | _Dillerland_ | Jerome Tuccille | [Amazon](https://www.amazon.com/dp/1593501242?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6518144) | 4.00 | 3
+3-D-6 | _Design and Information in Biology: From Molecules to Systems_ | J.A. Bryant_ | [Amazon](https://www.amazon.com/dp/B01JXWW21K?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2532237) | 4.00 | 1
+3-D-27 | _In The Words of Great Business Leaders_ | Julie M. Fenster_ | [Amazon](https://www.amazon.com/dp/0471348554?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2357327) | 4.00 | 1
+3-E-10 | _Inside Intel: Andrew Grove and the Rise of the World's Most Powerful Chip Company_ | Tim Jackson | [Amazon](https://www.amazon.com/dp/B019TMB7MY?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/984311) | 4.00 | 25
+3-F-25 | _Opening the Xbox: Inside Microsoft's Plan to Unleash an Entertainment Revolution_ | Dean Takahashi | [Amazon](https://www.amazon.com/dp/0761537082?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1258249) | 4.00 | 103
+4-A-22 | _The Digital Hand_ | James W. Cortada | [Amazon](https://www.amazon.com/dp/0195165888?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3041303) | 4.00 | 1
+4-A-23 | _The Digital Hand, Vol 3_ | James W. Cortada | [Amazon](https://www.amazon.com/dp/0195165861?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/11005322) | 4.00 | 1
+4-B-31 | _Burn Rate: Retrogrades In Astrology: Retrograde Planets_ | Michael Erlewine | [Amazon](https://www.amazon.com/dp/0979832845?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6452722) | 4.00 | 2
+4-C-2 | _Pattern Languages of Program Design 5 (Software Patterns Series)_ | Dragos Manolescu, Markus Voelter, James Noble | [Amazon](https://www.amazon.com/dp/0321321944?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/79768) | 4.00 | 5
+4-D-5 | _Data Structures & Algorithms in Java_ | Mitchell Waite, Robert Lafore | [Amazon](https://www.amazon.com/dp/1571690956?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/28672840) | 4.00 | 1
+5-B-23 | _The Undecidable: Basic Papers on Undecidable Propositions, Unsolvable Problems and Computable Functions (Dover Books on Mathematics)_ | Martin Davis | [Amazon](https://www.amazon.com/dp/0486432289?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1340806) | 4.00 | 10
+5-C-6 | _Games and Information: An Introduction to Game Theory Third Edition_ | Eric Rasmusen | [Amazon](https://www.amazon.com/dp/0631210954?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8752582) | 4.00 | 1
+5-D-16 | _The Social Business Imperative: Adapting Your Business Model to the Always-Connected Customer_ | Clara Shih | [Amazon](https://www.amazon.com/dp/013426343X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/29639181) | 4.00 | 3
+5-D-20 | _MCI:Failure Is Not an Option, How MCI Invented Competition in Telecommunications_ | Lorraine Spurge | [Amazon](https://www.amazon.com/dp/1888232412?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3111311) | 4.00 | 1
+5-E-27 | _Fire In The Belly: Building A World-leading High-tech Company From Scratch In Tumultuous Times_ | Jerry D. Neal,  Jerry Bledsoe | [Amazon](https://www.amazon.com/dp/1878086987?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/694925) | 4.00 | 8
+7-A-26 | _Power Struggles: Scientific Authority and the Creation of Practical Electricity Before Edison_ | Michael Brian Schiffer | [Amazon](https://www.amazon.com/dp/0262516160?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/19944981) | 4.00 | 2
+7-B-4 | _A Practical Guide to Linux_ | Mark G. Sobell | [Amazon](https://www.amazon.com/dp/0201895498?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/741155) | 4.00 | 20
+7-B-11 | _Embedded Linux_ | John Lombardo | [Amazon](https://www.amazon.com/dp/073570998X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2371355) | 4.00 | 2
+7-B-23 | _Linux Desktop Hacks: Tips & Tools for Customizing and Optimizing your OS_ | Nicholas Petreley,  Jono Bacon | [Amazon](https://www.amazon.com/dp/0596009119?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/688515) | 4.00 | 5
+7-C-10 | _50 Fast Mac OS X Techniques (50 Fast Techniques Series)_ | Joe Kissell | [Amazon](https://www.amazon.com/dp/0764539116?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2166451) | 4.00 | 1
+7-C-11 | _Mac OS X Power Tools, Second Edition_ | Dan Frakes,  Sybex | [Amazon](https://www.amazon.com/dp/0782143199?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2084949) | 4.00 | 0
+7-E-28 | _Professional Portal Development with Open Source Tools: JavaTM Portlet API, Lucene, James, Slide_ | W. Clay Richardson, Donald Avondolio, Joe Vitale,  Peter Len,  Kevin T. Smith | [Amazon](https://www.amazon.com/dp/0471469513?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/911056) | 4.00 | 2
+8-C-4 | _All Aboard: The Golden Age of American Rail Travel_ | Bill Yenne | [Amazon](https://www.amazon.com/dp/0880293535?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/779963) | 4.00 | 2
+8-D-22 | _From Edison to Marconi: The First Thirty Years of Recorded Music_ | David J. Steffen | [Amazon](https://www.amazon.com/dp/0786420618?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2476566) | 4.00 | 1
+8-D-32 | _Nikola Tesla: Colorado Springs Notes, 1899-1900_ | Nikola Tesla | [Amazon](https://www.amazon.com/dp/8087888243?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18477806) | 4.00 | 0
+8-E-8 | _It Happened On the Way to War: A Marine's Path to Peace_ | Rye Barcott | [Amazon](https://www.amazon.com/dp/B01F9FU8M0?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/9219343) | 4.00 | 796
+1-A-22 | _Project Orion: The True Story of the Atomic Spaceship_ | George Dyson | [Amazon](https://www.amazon.com/dp/0805059857?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/21243) | 3.99 | 256
+1-B-20 | _The Kingdom and the Power: Behind the Scenes at The New York Times: The Institution That Influences the World_ | Gay Talese | [Amazon](https://www.amazon.com/dp/0812977688?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/113855) | 3.99 | 297
+2-A-21 | _Complicated Women: Sex and Power in Pre-Code Hollywood_ | Mick LaSalle | [Amazon](https://www.amazon.com/dp/0312252072?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/564035) | 3.99 | 32
+2-B-3 | _A Private View_ | Irene Mayer Selznick | [Amazon](https://www.amazon.com/dp/0394401921?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1238423) | 3.99 | 65
+2-F-18 | _The Humane Interface: New Directions for Designing Interactive Systems_ | Jef Raskin | [Amazon](https://www.amazon.com/dp/0201379376?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/344726) | 3.99 | 774
+7-A-15 | _Desperate Networks_ | Bill Carter | [Amazon](https://www.amazon.com/dp/0385514409?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/14720) | 3.99 | 424
+8-B-8 | _The Big Rich: The Rise and Fall of the Greatest Texas Oil Fortunes_ | Bryan Burrough | [Amazon](https://www.amazon.com/dp/1594201994?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3554517) | 3.99 | 1268
+3-B-10 | _W. C. Fields by Himself: His Intended Autobiography_ | W.C. Fields | [Amazon](https://www.amazon.com/dp/B011MEFXAY?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1251360) | 3.98 | 39
+3-E-32 | _Force For Change_ | John P. Kotter | [Amazon](https://www.amazon.com/dp/0029184657?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/251734) | 3.98 | 78
+4-A-2 | _Computability and Logic_ | Boolos George Jeffrey Richard C Burgess John P | [Amazon](https://www.amazon.com/dp/0521389232?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1556746) | 3.98 | 82
+5-C-25 | _Delivering Happiness: A Path to Profits, Passion, and Purpose; A Round Table Comic_ | Tony Hsieh, Rob Ten Pas | [Amazon](https://www.amazon.com/dp/1610660242?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/19053660) | 3.98 | 262
+1-B-8 | _Masters of Enterprise_ | H.W. Brands | [Amazon](https://www.amazon.com/dp/143914401X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/41654) | 3.97 | 85
+1-B-15 | _Privileged Son: Otis Chandler And The Rise And Fall Of The L.a. Times Dynasty_ | Dennis McDougal | [Amazon](https://www.amazon.com/dp/0306811618?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3016) | 3.97 | 11
+1-B-16 | _Privileged Son: Otis Chandler And The Rise And Fall Of The L.a. Times Dynasty_ | Dennis McDougal | [Amazon](https://www.amazon.com/dp/0306811618?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3016) | 3.97 | 11
+1-D-25 | _Wired for War: The Robotics Revolution and Conflict in the 21st Century_ | P. W. Singer | [Amazon](https://www.amazon.com/dp/1594201986?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6098718) | 3.97 | 1516
+2-C-23 | _An Empire of Their Own: How the Jews Invented Hollywood_ | Neal Gabler | [Amazon](https://www.amazon.com/dp/0385265573?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13498889) | 3.97 | 2
+4-F-8 | _Even Faster Web Sites_ | Steve Souders, Tim O'Reilly |  \| [Goodreads](https://www.goodreads.com/book/show/6438581) | 3.97 | 292
+5-B-5 | _Programming the Universe: A Quantum Computer Scientist Takes on the Cosmos_ | Seth Lloyd | [Amazon](https://www.amazon.com/dp/1400033861?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/331680) | 3.97 | 1392
+8-D-31 | _Prodigal Genius: The Life of Nikola Tesla_ | John J. O'Neill | [Amazon](https://www.amazon.com/dp/1931882851?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3841527) | 3.97 | 25
+8-E-4 | _Richard Branson: Losing My Virginity: How I've Had Fun & Made a Fortune Doing Business My Way_ | Richard Branson | [Amazon](https://www.amazon.com/dp/0812931017?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/883776) | 3.97 | 32
+8-E-15 | _The Billionaire Who Wasn't: How Chuck Feeney Secretly Made and Gave Away a Fortune_ | Conor O'Clery | [Amazon](https://www.amazon.com/dp/B00ZY92BUE?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2842145) | 3.97 | 294
+2-D-2 | _Programming Language Pragmatics_ | Michael L. Scott_ | [Amazon](https://www.amazon.com/dp/0123745144?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/36412270) | 3.96 | 0
+3-D-5 | _Apple: The Intrigue, Egomania and Business Blunders That Toppled an American Icon (Century Business)_ | Jim Carlton | [Amazon](https://www.amazon.com/dp/0712679014?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/581496) | 3.96 | 152
+3-F-18 | _Hitchcock's Notebooks:: An Authorized And Illustrated Look Inside The Creative Mind Of Alfred Hitchcook_ | Dan Auiler | [Amazon](https://www.amazon.com/dp/0380977834?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/15078) | 3.96 | 67
+7-C-3 | _Mac OS X Leopard: The Missing Manual_ | David Pogue | [Amazon](https://www.amazon.com/dp/059652952X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/283887) | 3.96 | 167
+8-B-6 | _Oil, God, and Gold: The Story of Aramco and the Saudi Kings_ | Anthony Cave Brown | [Amazon](https://www.amazon.com/dp/0395592208?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1100358) | 3.96 | 24
+1-C-21 | _Crosley: Two Brothers and a Business Empire That Transformed the Nation_ | David Stern, Michael A. Banks, Rusty McClure | [Amazon](https://www.amazon.com/dp/1578602912?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/655736) | 3.95 | 62
+1-D-21 | _Desilu: The Story of Lucille Ball and Desi Arnaz_ | Coyne S. Sanders, Tom Gilbert | [Amazon](https://www.amazon.com/dp/0062020013?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10139405) | 3.95 | 58
+2-C-11 | _Only The Paranoid Survive by Andrew Grove_ | Andrew S. Grove | [Amazon](https://www.amazon.com/dp/B011T7UXC2?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/66863) | 3.95 | 4012
+2-E-9 | _Lost in the Funhouse: The Life and Mind of Andy Kaufman_ | Bill Zehme | [Amazon](https://www.amazon.com/dp/1841152307?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/12889) | 3.95 | 537
+2-F-11 | _The Wealth of Networks: How Social Production Transforms Markets and Freedom_ | Yochai Benkler | [Amazon](https://www.amazon.com/dp/0300125771?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/14721) | 3.95 | 1204
+4-A-14 | _Electronic Brains: Stories from the Dawn of the Computer Age_ | Mike Hally |  \| [Goodreads](https://www.goodreads.com/book/show/2103666) | 3.95 | 21
+4-B-15 | _Colossus: The First Electronic Computer (Popular Science)_ | Jack Copeland | [Amazon](https://www.amazon.com/dp/019284055X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/20103824) | 3.95 | 2
+4-E-1 | _Rapid Development: Taming Wild Software Schedules_ | Steve McConnell | [Amazon](https://www.amazon.com/dp/1556159005?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/93892) | 3.95 | 1059
+8-B-5 | _Big Coal: The Dirty Secret Behind America's Energy Future_ | Jeff Goodell | [Amazon](https://www.amazon.com/dp/0618319409?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/318364) | 3.95 | 298
+1-A-13 | _Curse of the Mogul: What's Wrong With the World's Leading Media Companies_ | Jonathan A. Knee | [Amazon](https://www.amazon.com/dp/B004C7GT0M?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7162410) | 3.94 | 81
+2-E-27 | _Complex Adaptive Systems: An Introduction to Computational Models of Social Life_ | John H. Miller, Scott E. Page | [Amazon](https://www.amazon.com/dp/0691127026?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/245273) | 3.94 | 282
+4-B-30 | _The Book of Xen_ | Luke S. Crawford, Chris Takemura |  \| [Goodreads](https://www.goodreads.com/book/show/6673211) | 3.94 | 23
+5-B-27 | _Real World Haskell_ | Bryan O'Sullivan, John Goerzen, Don Stewart | [Amazon](https://www.amazon.com/dp/0596514980?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/25582963) | 3.94 | 6
+5-D-19 | _Cut Throat (Triple Crown Publications Presents)_ | K Roland Williams | [Amazon](https://www.amazon.com/dp/0979951739?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2859531) | 3.94 | 49
+8-B-3 | _A Summer Bright and Terrible: Winston Churchill, Lord Dowding, Radar, and the Impossible Triumph of the Battle of Britain_ | David E. Fisher | [Amazon](https://www.amazon.com/dp/1593761163?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/124618) | 3.94 | 38
+8-C-3 | _Nothing Like It in the World: The Men Who Built the Transcontinental Railroad, 1863-1869_ | Stephen E. Ambrose | [Amazon](https://www.amazon.com/dp/0684846098?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/49255) | 3.94 | 8389
+1-A-26 | _The Second Coming of Steve Jobs_ | Alan Deutschman | [Amazon](https://www.amazon.com/dp/0767904338?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/56545) | 3.93 | 2039
+2-C-1 | _D.W. Griffith by Richard Schickel_ | Richard Schickel | [Amazon](https://www.amazon.com/dp/0671225960?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2220381) | 3.93 | 13
+2-C-17 | _Goldwyn: A Biography_ | A. Scott Berg | [Amazon](https://www.amazon.com/dp/1573227234?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/354050) | 3.93 | 254
+2-E-22 | _The Second Coming of Steve Jobs_ | Alan Deutschman | [Amazon](https://www.amazon.com/dp/0767904338?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/56545) | 3.93 | 2039
+2-E-23 | _I'm Dying Up Here: Heartbreak and High Times in Stand-Up Comedy's Golden Era_ | William Knoedelseder | [Amazon](https://www.amazon.com/dp/B015QKYXC4?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1698163) | 3.93 | 956
+3-A-24 | _Call Me Ted_ | Ted Turner | [Amazon](https://www.amazon.com/dp/B01F9GFB26?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3722134) | 3.93 | 1142
+4-F-18 | _Electrifying America: Social Meanings of a New Technology, 1880-1940_ | David E. Nye | [Amazon](https://www.amazon.com/dp/0262140489?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/187357) | 3.93 | 63
+5-D-1 | _Tog on Software Design_ | Bruce Tognazzini | [Amazon](https://www.amazon.com/dp/0201489171?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1132915) | 3.93 | 28
+1-B-1 | _American Aurora: A Democratic-Republican Returns; The Suppressed History of Our Nation's Beginnings and the Heroic Newspaper That Tried to Report It_ | Richard N. Rosenfeld | [Amazon](https://www.amazon.com/dp/0312194374?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1216800) | 3.92 | 57
+2-A-30 | _Geek Silicon Valley: The Inside Guide To Palo Alto, Stanford, Menlo Park, Mountain View, Santa Clara, Sunnyvale, San Jose, San Francisco_ | Ashlee Vance | [Amazon](https://www.amazon.com/dp/0762742399?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6654345) | 3.92 | 101
+2-B-8 | _When Hollywood Had a King_ | Connie Bruck | [Amazon](https://www.amazon.com/dp/0812972171?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/100787) | 3.92 | 69
+2-D-14 | _Who the Hell's in It: Conversations with Hollywood's Legendary Actors_ | Peter Bogdanovich | [Amazon](https://www.amazon.com/dp/0345480023?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/372111) | 3.92 | 172
+2-F-12 | _The Nature of Technology: What It Is and How It Evolves_ | W. Brian Arthur | [Amazon](https://www.amazon.com/dp/1416544062?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6321234) | 3.92 | 289
+2-F-26 | _Defying Gravity: The Making of Newton_ | Markos Kounalakis, Doug Menuez (Photographer) | [Amazon](https://www.amazon.com/dp/0941831949?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2347472) | 3.92 | 26
+3-F-17 | _The Pixar Touch: The Making of a Company_ | David A. Price | [Amazon](https://www.amazon.com/dp/B004SUYB7Q?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2632830) | 3.92 | 5027
+4-F-10 | _Beyond Reality: Evidence of Parallel Universes Beyond Reality: Evidence of Parallel Universes_ | Shelley Kaehr |  \| [Goodreads](https://www.goodreads.com/book/show/375888) | 3.92 | 7
+5-A-21 | _Weapons Grade: How Modern Warfare Gave Birth to Our High-Tech World_ | David Hambling | [Amazon](https://www.amazon.com/dp/0786715618?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1607863) | 3.92 | 9
+5-C-24 | _Speeding the Net: The Inside Story of Netscape and How It Challenged Microsoft_ | Joshua Quittner, Michelle Slatalla | [Amazon](https://www.amazon.com/dp/0871137097?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/587023) | 3.92 | 25
+8-C-5 | _Empire Express: Building the First Transcontinental Railroad_ | David Haward Bain | [Amazon](https://www.amazon.com/dp/067080889X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/468080) | 3.92 | 200
+1-B-13 | _Just for Fun: The Story of an Accidental Revolutionary_ | Linus Torvalds | [Amazon](https://www.amazon.com/dp/B01FKTAJDS?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2134053) | 3.91 | 135
+1-B-19 | _The Trust: The Private and Powerful Family Behind The New York Times_ | Susan E. Tifft,  Alex S. Jones | [Amazon](https://www.amazon.com/dp/0316836311?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/856) | 3.91 | 25
+1-B-22 | _City Room_ | Arthur Gelb | [Amazon](https://www.amazon.com/dp/0425198316?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/383170) | 3.91 | 84
+2-D-29 | _Brilliant, Crazy, Cocky: How the Top 1% of Entrepreneurs Profit from Global Chaos_ | Sarah Lacy | [Amazon](https://www.amazon.com/dp/0470580097?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10271899) | 3.91 | 146
+3-E-29 | _Andy Grove: The Life and Times of an American_ | Richard S. Tedlow | [Amazon](https://www.amazon.com/dp/1591841399?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/242433) | 3.91 | 81
+4-A-21 | _The Turk: The Life and Times of the Famous Eighteenth-Century Chess-Playing Machine_ | Tom Standage | [Amazon](https://www.amazon.com/dp/0425190390?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/158712) | 3.91 | 375
+5-B-20 | _Information Science_ | David G. Luenberger |  \| [Goodreads](https://www.goodreads.com/book/show/433463) | 3.91 | 11
+5-E-7 | _On Wings of Eagles: The Inspiring True Story of One Man's Patriotic Spirit--and His Heroic Mission to Save His Countrymen_ | Kin Follett | [Amazon](https://www.amazon.com/dp/0451213092?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5058) | 3.91 | 6868
+5-E-15 | _Thriving on Chaos: Handbook for a Management Revolution_ | Tom Peters | [Amazon](https://www.amazon.com/dp/0394567846?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/318806) | 3.91 | 1939
+2-E-15 | _What Happens Next: A History of American Screenwriting_ | Marc Norman | [Amazon](https://www.amazon.com/dp/0307393887?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/420639) | 3.90 | 92
+2-E-26 | _Lessons in Excellence from Charlie Trotter_ | Paul Clarke Author, Charlie Trotter | [Amazon](https://www.amazon.com/dp/0898159083?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/273085) | 3.90 | 85
+5-C-31 | _Agile Web Development with Rails: A Pragmatic Guide (Pragmatic Programmers)_ | Dave Thomas, David Heinemeier Hansson, Leon Breedt, | [Amazon](https://www.amazon.com/dp/097669400X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/45) | 3.90 | 1142
+1-A-25 | _Steve Jobs, the Journey Is the Reward_ | Jeffrey S. Young | [Amazon](https://www.amazon.com/dp/155802378X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/21260945) | 3.89 | 18
+2-D-31 | _Where Wizards Stay Up Late: The Origins Of The Internet_ | Katie Hafner | [Amazon](https://www.amazon.com/dp/0684832674?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/281818) | 3.89 | 2550
+2-D-34 | _The Millennium Bug: How to Survive the Coming Chaos_ | Michael S. Hyatt | [Amazon](https://www.amazon.com/dp/0471722464?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1654698) | 3.89 | 63
+2-E-25 | _Lessons in Service from Charlie Trotter_ | Ed Lawler, Charlie Trotter | [Amazon](https://www.amazon.com/dp/1580083153?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/273068) | 3.89 | 123
+3-A-3 | _In All His Glory_ | Sally Bedell Smith | [Amazon](https://www.amazon.com/dp/0671617354?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/643648) | 3.89 | 46
+5-A-19 | _Programming Interactivity: A Designer's Guide to Processing, Arduino, and Openframeworks_ | Joshua Noble | [Amazon](https://www.amazon.com/dp/0596154143?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6704793) | 3.89 | 79
+5-C-9 | _City of Light (Outcast)_ | Keri Arthur |  \| [Goodreads](https://www.goodreads.com/book/show/25170761) | 3.89 | 1063
+5-E-20 | _Wireless Nation: The Frenzied Launch Of The Cellular Revolution_ | James B. Murray, James B. Murray, Lisa Dickey | [Amazon](https://www.amazon.com/dp/0738206881?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1529441) | 3.89 | 23
+7-B-18 | _Shell Scripting Recipes: A Problem-Solution Approach (Expert's Voice in Open Source)_ | Chris Johnson | [Amazon](https://www.amazon.com/dp/1590594711?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/464896) | 3.89 | 8
+8-E-22 | _Winner Takes All: Steve Wynn, Kirk Kerkorian, Gary Loveman, and the Race to Own Las Vegas_ | Christina Binkley | [Amazon](https://www.amazon.com/dp/1401309763?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2231329) | 3.89 | 210
+1-C-2 | _The Times of My Life and My Life with the Times_ | Max Frankel | [Amazon](https://www.amazon.com/dp/0679448241?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3954193) | 3.88 | 10
+1-D-24 | _Warm Up the Snake: A Hollywood Memoir_ | John Rich |  \| [Goodreads](https://www.goodreads.com/book/show/2633608) | 3.88 | 8
+2-A-17 | _History of the American Cinema: The Talkies_ | Donald Crafton | [Amazon](https://www.amazon.com/dp/0520221281?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/784161) | 3.88 | 15
+2-B-20 | _The Chief The Life of William Randolph Hearst_ | David Nasaw | [Amazon](https://www.amazon.com/dp/B001ISFZ7G?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2053811) | 3.88 | 27
+2-B-21 | _The Chief: The Life of William Randolph Hearst_ | David Nasaw | [Amazon](https://www.amazon.com/dp/0618154469?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/75463) | 3.88 | 497
+2-C-7 | _Inside Steve's Brain_ | Leander Kahney | [Amazon](https://www.amazon.com/dp/1591845513?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2363692) | 3.88 | 3300
+2-D-26 | _How We Got Here: A Slightly Irreverent History of Technology and Markets_ | Andy Kessler | [Amazon](https://www.amazon.com/dp/0060840978?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1352456) | 3.88 | 123
+4-B-14 | _The Physics of Quantum Information_ | Dirk Bouwmeester, Artur K. Ekert, Anton Zeilinger | [Amazon](https://www.amazon.com/dp/3540667784?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/100029) | 3.88 | 8
+4-D-20 | _Design Patterns Explained_ | Alan Shalloway, James R. Trott | [Amazon](https://www.amazon.com/dp/0321247140?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/85021) | 3.88 | 216
+4-F-1 | _jQuery Cookbook: Solutions & Examples for jQuery Developers (Animal Guide)_ | Cody Lindley | [Amazon](https://www.amazon.com/dp/0596159773?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7107155) | 3.88 | 197
+5-A-15 | _Discrete Mathematics and Its Applications_ | Kenneth H. Rosen | [Amazon](https://www.amazon.com/dp/0072899050?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1800803) | 3.88 | 779
+6-F-3 | _Inside Steve's Brain, Expanded Edition_ | Leander Kahney | [Amazon](https://www.amazon.com/dp/1591842972?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6653187) | 3.88 | 78
+1-C-24 | _Hello, Everybody!: The Dawn of American Radio_ | Anthony Rudel | [Amazon](https://www.amazon.com/dp/015101275X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3185210) | 3.87 | 61
+2-C-24 | _The Difference Between God and Larry Ellison*: Inside Oracle Corporation; *God Doesn't Think He's Larry Ellison_ | Mike Wilson | [Amazon](https://www.amazon.com/dp/B0027BY6E6?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4897852) | 3.87 | 18
+3-B-8 | _The Essential Groucho: Writings by, for, and about Groucho Marx_ | Stefan Kanfer | [Amazon](https://www.amazon.com/dp/037570213X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/983569) | 3.87 | 229
+4-B-16 | _Processing: Creative Coding and Generative Art in Processing 2_ | Ira Greenberg, Dianna Xu, Deepak Kumar | [Amazon](https://www.amazon.com/dp/143024464X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/14975340) | 3.87 | 13
+7-A-4 | _Weaving the Web: The Original Design and Ultimate Destiny of the World Wide Web_ | Tim Berners-Lee | [Amazon](https://www.amazon.com/dp/006251587X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/821987) | 3.87 | 324
+1-B-9 | _Lincoln Steffens: A Biography_ | Justin Kaplan | [Amazon](https://www.amazon.com/dp/B01FKUIV3W?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2233834) | 3.86 | 1
+1-C-16 | _The Great American Broadcast: A Celebration of Radio's Golden Age_ | Leonard Maltin | [Amazon](https://www.amazon.com/dp/0525941835?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1639658) | 3.86 | 38
+1-C-17 | _Winchell: Gossip, Power, and the Culture of Celebrity_ | Neal Gabler | [Amazon](https://www.amazon.com/dp/0679764399?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/281870) | 3.86 | 138
+3-D-10 | _Startup Rising_ | Christopher M. Schroeder | [Amazon](https://www.amazon.com/dp/0230342221?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/16059503) | 3.86 | 137
+3-F-2 | _Return to the Little Kingdom: Steve Jobs and the Creation of Apple_ | Michael Moritz | [Amazon](https://www.amazon.com/dp/1590204018?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6937258) | 3.86 | 529
+3-F-29 | _The Geek Atlas_ | John Graham-Cumming | [Amazon](https://www.amazon.com/dp/0596523203?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6469386) | 3.86 | 172
+4-B-6 | _Genetic Programming: An Introduction_ | Wolfgang Banzhaf, Peter Nordin, Robert E. Keller, Frank D. Francone | [Amazon](https://www.amazon.com/dp/1493303570?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1061734) | 3.86 | 20
+5-A-10 | _Tog on Interface_ | Bruce Tognazzini |  \| [Goodreads](https://www.goodreads.com/book/show/528786) | 3.86 | 63
+5-A-12 | _Literate Programming (Lecture Notes)_ | Donald E. Knuth | [Amazon](https://www.amazon.com/dp/0937073806?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/112245) | 3.86 | 89
+5-E-23 | _Money from Thin Air: The Story of Craig McCaw, the Visionary who Invented the Cell Phone Industry, and His Next Billion-Dollar Idea_ | O. Casey Corr | [Amazon](https://www.amazon.com/dp/0812926978?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18608) | 3.86 | 22
+5-F-2 | _Masterminds of Programming: Conversations with the Creators of Major Programming Languages_ | Federico Biancuzzi, Chromatic | [Amazon](https://www.amazon.com/dp/0596515170?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1746425) | 3.86 | 329
+7-B-30 | _Learning the bash Shell: Unix Shell Programming_ | Cameron Newham | [Amazon](https://www.amazon.com/dp/0596009658?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/299534) | 3.86 | 368
+7-E-18 | _The Definitive Guide to Django: Web Development Done Right_ | Adrian Holovaty, Jacob Kaplan-Moss | [Amazon](https://www.amazon.com/dp/143021936X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/554529) | 3.86 | 143
+8-D-5 | _Innovate Like Edison: The Five-Step System for Breakthrough Business Success_ | Michael J. Gelb, Sarah Miller Caldicott | [Amazon](https://www.amazon.com/dp/0452289823?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/465160) | 3.86 | 67
+1-D-19 | _Ball of Fire: The Tumultous Life and Comic Art of Lucille Ball_ | Stefan Kanfer | [Amazon](https://www.amazon.com/dp/0571220304?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1415318) | 3.85 | 6
+3-B-3 | _The Skeptic: A Life of H.L. Mencken_ | Terry Teachout | [Amazon](https://www.amazon.com/dp/006050529X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/206211) | 3.85 | 178
+4-C-6 | _Pattern-Oriented Software Architecture Volume 1: A System of Patterns_ | Frank Buschmann, Hans Rohnert |  \| [Goodreads](https://www.goodreads.com/book/show/85039) | 3.85 | 137
+4-E-11 | _Planning Extreme Programming_ | Kent Beck,  Martin Fowler | [Amazon](https://www.amazon.com/dp/0201710919?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/67839) | 3.85 | 284
+7-B-16 | _Linux Server Hacks: 100 Industrial-Strength Tips and Tools_ | Rob Flickenger | [Amazon](https://www.amazon.com/dp/0596004613?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/86607) | 3.85 | 129
+8-D-11 | _Edison - A Biography_ | Matthew Josephson | [Amazon](https://www.amazon.com/dp/0965569934?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/502056) | 3.85 | 8
+1-C-8 | _The Creation of the Media: Political Origins of Modern Communications_ | Paul Starr | [Amazon](https://www.amazon.com/dp/0465081940?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/648765) | 3.84 | 124
+1-D-26 | _Free: The Future of a Radical Price_ | Chris Anderson | [Amazon](https://www.amazon.com/dp/1401322905?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6150530) | 3.84 | 11502
+2-A-25 | _Adventures of a Hollywood Secretary: Her Private Letters from Inside the Studios of the 1920s_ | Valeria Belletti | [Amazon](https://www.amazon.com/dp/0520247809?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/707377) | 3.84 | 83
+3-B-19 | _The Game Show King: A Confession_ | Chuck Barris | [Amazon](https://www.amazon.com/dp/0786700025?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/537256) | 3.84 | 43
+3-D-24 | _Data and Computer Communications_ | William Stallings | [Amazon](https://www.amazon.com/dp/0132433109?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/299634) | 3.84 | 165
+4-F-4 | _Search Patterns: Design for Discovery_ | Peter Morville, Jeffery Callender | [Amazon](https://www.amazon.com/dp/0596802277?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7088205) | 3.84 | 221
+1-A-17 | _In The Plex: How Google Thinks, Works, and Shapes Our Lives_ | Steven Levy | [Amazon](https://www.amazon.com/dp/1416596585?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7841446) | 3.83 | 21199
+2-E-4 | _Show and Tell: New Yorker Profiles_ | John Lahr | [Amazon](https://www.amazon.com/dp/1585670626?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/292190) | 3.83 | 17
+3-E-26 | _The Silicon Valley Edge: A Habitat for Innovation and Entrepreneurship_ | William F. Miller and Chong-Moon Lee | [Amazon](https://www.amazon.com/dp/0804740631?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/313707) | 3.83 | 6
+3-F-10 | _iWoz Computer Geek to Cult Icon: How I Invented the Personal Computer and Had Fun Along the Way_ | Steve Wozniak | [Amazon](https://www.amazon.com/dp/B0140E7CXE?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/798635) | 3.83 | 6272
+3-F-14 | _What the Dormouse Said: How the Sixties Counterculture Shaped the Personal Computer Industry_ | John Markoff | [Amazon](https://www.amazon.com/dp/B019TLYPU6?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4844) | 3.83 | 66
+4-D-8 | _Data Structures and Algorithms with Object-Oriented Design Patterns in Java_ | Bruno R. Preiss | [Amazon](https://www.amazon.com/dp/0471346136?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/475635) | 3.83 | 6
+4-E-2 | _Software Project Survival Guide_ | Steve McConnell | [Amazon](https://www.amazon.com/dp/1572316217?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/93894) | 3.83 | 427
+4-E-22 | _Patterns of Software: Tales from the Software Community_ | Richard P. Gabriel | [Amazon](https://www.amazon.com/dp/019510269X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/685486) | 3.83 | 70
+7-A-24 | _Wetware: A Computer in Every Living Cell_ | Dennis Bray | [Amazon](https://www.amazon.com/dp/0300167849?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5510571) | 3.83 | 137
+7-C-23 | _Computer Security Basics_ | Rick Lehtinen, G. T., Sr. Gangemi | [Amazon](https://www.amazon.com/dp/0596006691?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/457138) | 3.83 | 28
+7-E-32 | _Cocoon: Building XML Applications_ | Carsten Ziegeler, Matthew Langham | [Amazon](https://www.amazon.com/dp/0735712352?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1668195) | 3.83 | 6
+8-A-7 | _Search Engines: Information Retrieval in Practice_ | Bruce Croft, Donald Metzler, Trevor Strohman | [Amazon](https://www.amazon.com/dp/0136072240?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6571987) | 3.83 | 45
+1-A-12 | _Appetite for Self-Destruction- The Rise & Fall of the Record Industry in the Digital Age_ | Knopper, Steve | [Amazon](https://www.amazon.com/dp/B008AU80RW?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4805529) | 3.82 | 802
+1-C-20 | _Raised on Radio_ | Gerald Nachman | [Amazon](https://www.amazon.com/dp/0520223039?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/549109) | 3.82 | 34
+2-B-4 | _King Cohn: The Life and Times of Harry Cohn_ | Bob Thomas | [Amazon](https://www.amazon.com/dp/1893224074?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/590013) | 3.82 | 64
+2-B-12 | _Seeking Pleasure in the Old West_ | David Dary | [Amazon](https://www.amazon.com/dp/0700608281?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1630129) | 3.82 | 1
+2-C-19 | _Conversations with My Agent by Long_ | Rob Long | [Amazon](https://www.amazon.com/dp/B014GG4BIK?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/301448) | 3.82 | 62
+2-D-25 | _Vanity Fair's Tales Of Hollywood's_ | Graydon Carter | [Amazon](https://www.amazon.com/dp/0143114719?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3558187) | 3.82 | 165
+2-F-17 | _The Perfect Store: Inside eBay_ | Adam Cohen | [Amazon](https://www.amazon.com/dp/0316164933?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/324739) | 3.82 | 355
+3-B-18 | _Charlie Chaplin and His Times_ | Kenneth S. Lynn_ | [Amazon](https://www.amazon.com/dp/068480851X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/887368) | 3.82 | 71
+3-E-16 | _Big Blues: The Unmaking of IBM_ | Paul Carroll | [Amazon](https://www.amazon.com/dp/B01FKTWS9Q?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1044300) | 3.82 | 6
+3-E-22 | _HP Way: How Bill Hewlett and I Built Our Company_ | David Packard | [Amazon](https://www.amazon.com/dp/0887307566?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1694071) | 3.82 | 770
+4-A-11 | _The Best Software Writing I: Selected and Introduced_ | Avram Joel Spolsky |  \| [Goodreads](https://www.goodreads.com/book/show/41787) | 3.82 | 533
+4-B-27 | _Here Comes Everybody: The Power of Organizing Without Organizations_ | Clay Shirky | [Amazon](https://www.amazon.com/dp/0143114948?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6062744) | 3.82 | 410
+4-B-28 | _Object-Oriented Analysis and Design_ | James Martin |  \| [Goodreads](https://www.goodreads.com/book/show/6062744) | 3.82 | 410
+4-E-21 | _Holub on Patterns: Learning Design Patterns by Looking at Code (Books for Professionals by Professionals)_ | Allen Holub | [Amazon](https://www.amazon.com/dp/159059388X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/475662) | 3.82 | 32
+5-C-28 | _The Google Story: Inside the Hottest Business, Media, and Technology Success of Our Time_ | David A. Vise |  \| [Goodreads](https://www.goodreads.com/book/show/164323) | 3.82 | 11571
+5-D-29 | _The Moral Molecule: The Source of Love and Prosperity 1st (first) Edition by Zak, Paul J. published by Dutton Adult (2012)_ | Paul J. Zak | [Amazon](https://www.amazon.com/dp/B00E6T67YE?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13386769) | 3.82 | 269
+5-E-21 | _Sony: The Private Life_ | John Nathan | [Amazon](https://www.amazon.com/dp/0395893275?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/274878) | 3.82 | 74
+7-A-7 | _The Cathedral & the Bazaar: Musings on Linux and Open Source by an Accidental Revolutionary_ | Eric S. Raymond | [Amazon](https://www.amazon.com/dp/0596001088?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/134825) | 3.82 | 2699
+7-C-2 | _Mac OS X Tiger: Missing Manual_ | David Pogue | [Amazon](https://www.amazon.com/dp/0596009410?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/31974) | 3.82 | 91
+8-E-3 | _The Making of a Blockbuster: How Wayne Huizenga Built a Sports and Entertainment Empire from Trash, Grit, and Videotape_ | Gail DeGeorge | [Amazon](https://www.amazon.com/dp/0471122696?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/215117) | 3.82 | 45
+1-C-13 | _Free as in Freedom: Richard Stallman's Crusade for Free Software_ | Sam Williams | [Amazon](https://www.amazon.com/dp/0596002874?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/658332) | 3.81 | 707
+1-C-23 | _Edward R. Murrow and the Birth of Broadcast Journalism_ | Bob Edwards | [Amazon](https://www.amazon.com/dp/0471477532?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/310451) | 3.81 | 254
+1-F-2 | _Cognitive Surplus: Creativity and Generosity in a Connected Age by Clay Shirky_ | Clay Shirky | [Amazon](https://www.amazon.com/dp/B01FIVY6IC?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7614793) | 3.81 | 4270
+5-C-2 | _Information Theory And Evolution (2nd Edition)_ | John Scales Avery | [Amazon](https://www.amazon.com/dp/9814401234?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/15244742) | 3.81 | 4
+5-C-26 | _Netscape Time: The Making of the Billion-Dollar Start-Up That Took on Microsoft_ | Jim Clark, Owen Edwards |  \| [Goodreads](https://www.goodreads.com/book/show/2345073) | 3.81 | 44
+7-C-1 | _Big Book of Apple Hacks: Tips & Tools for unlocking the power of your Apple devices_ | Chris Seibold | [Amazon](https://www.amazon.com/dp/0596529821?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/903499) | 3.81 | 16
+7-C-4 | _Switching to the Mac: The Missing Manual, El Capitan Edition_ | David Pogue | [Amazon](https://www.amazon.com/dp/1491917970?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7190944) | 3.81 | 33
+8-A-17 | _Long Tail Why the Future of Business is Selling Less of More by Anderson, Chris_ | Anderson | [Amazon](https://www.amazon.com/dp/B00DU78M0U?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2467566) | 3.81 | 16538
+2-B-16 | _Rogue Leaders: The Story of LucasArts_ | Rob Smith, George Lucas | [Amazon](https://www.amazon.com/dp/0811861848?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4721989) | 3.80 | 93
+2-D-2 | _Who Invented the Computer? The Legal Battle That Changed Computing History_ | Alice Rowe Burks | [Amazon](https://www.amazon.com/dp/1591020344?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/305466) | 3.80 | 5
+2-D-13 | _Down and Dirty Pictures: Miramax, Sundance, and the Rise of Independent Film_ | Peter Biskind | [Amazon](https://www.amazon.com/dp/0684862581?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/52570) | 3.80 | 1944
+3-D-16 | _Charles M. Schulz: Conversations_ | M. Thomas Inge_ | [Amazon](https://www.amazon.com/dp/1578063051?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/26155) | 3.80 | 48
+3-D-20 | _Computational Complexity: A Conceptual Perspective_ | Oded Goldreich | [Amazon](https://www.amazon.com/dp/052188473X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3363395) | 3.80 | 5
+3-D-25 | _Behind Deep Blue by Hsu_ | Feng-Hsiung Hsu | [Amazon](https://www.amazon.com/dp/B013PQPYLA?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/586433) | 3.80 | 101
+3-F-8 | _The Greatest Sci-fi Movies Never Made, Revised and Expanded Edition_ | David Hughes | [Amazon](https://www.amazon.com/dp/1845767551?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3194072) | 3.80 | 312
+4-A-34 | _HYPERGROWTH: How the Customer-Driven Model Is Revolutionizing the Way Businesses Build Products, Teams, & Brands_ | David Cancel | [Amazon](https://www.amazon.com/dp/1520743777?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/34019213) | 3.80 | 25
+4-E-6 | _Agile Software Development with Scrum_ | Ken Schwaber, Mike Beedle | [Amazon](https://www.amazon.com/dp/0130676349?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/349419) | 3.80 | 761
+7-A-1 | _Going Out: The Rise and Fall of Public Amusements by David Nasaw (1993-11-03)_ | David Nasaw | [Amazon](https://www.amazon.com/dp/0674356225?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/811662) | 3.80 | 65
+7-A-8 | _Cheap Amusements: Working Women and Leisure in Turn-of-the-Century New York_ | Kathy Peiss | [Amazon](https://www.amazon.com/dp/0877225001?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/307092) | 3.80 | 659
+7-A-19 | _Programming the Cell Processor: For Games, Graphics, and Computation_ | Matthew Scarpino | [Amazon](https://www.amazon.com/dp/0136008860?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4071329) | 3.80 | 5
+7-B-12 | _Building Embedded Linux Systems_ | Karim Yaghmour, Jon Masters, Gilad Ben-Yossef, Philippe Gerum | [Amazon](https://www.amazon.com/dp/0596529686?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1117201) | 3.80 | 58
+7-C-12 | _Mac OS X Hints_ | Rob Griffiths, David Pogue | [Amazon](https://www.amazon.com/dp/0596004516?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2166615) | 3.80 | 5
+7-D-2 | _Windows XP Power Tools_ | Jim Boyce | [Amazon](https://www.amazon.com/dp/078214067X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1353029) | 3.80 | 5
+7-E-30 | _Apache Jakarta-Tomcat_ | James Goodwill | [Amazon](https://www.amazon.com/dp/1893115364?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1308881) | 3.80 | 5
+8-D-10 | _Edison and the Electric Chair: A Story of Light and Death_ | Mark Essig | [Amazon](https://www.amazon.com/dp/0802777104?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/749140) | 3.80 | 145
+2-B-18 | _Jack Straight from the Gut_ | Jack Welch | [Amazon](https://www.amazon.com/dp/B006XYH0QO?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5559) | 3.79 | 10635
+2-F-15 | _Confessions of a Wall Street Analyst : A True Story of Inside Information and Corruption in the Stock Market_ | Jennifer Reingold, Daniel Reingold | [Amazon](https://www.amazon.com/dp/B004HOX6FG?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/87530) | 3.79 | 723
+4-C-15 | _Analysis Patterns: Reusable Object Models_ | Martin Fowler, Ralph Johnson, Ward Cunningham |  \| [Goodreads](https://www.goodreads.com/book/show/85002) | 3.79 | 199
+7-E-37 | _Dynamics of Software Development_ | Jim McCarthy | [Amazon](https://www.amazon.com/dp/B011SJAFTC?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1416996) | 3.79 | 112
+8-B-7 | _Inside Apple: How America's Most Admired--and Secretive--Company Really Works_ | Adam Lashinsky | [Amazon](https://www.amazon.com/dp/1455512168?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13055451) | 3.79 | 4496
+8-C-11 | _Inside Apple: How America's Most Admired--and Secretive--Company Really Works_ | Adam Lashinsky | [Amazon](https://www.amazon.com/dp/1455512168?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13055451) | 3.79 | 4496
+8-D-27 | _Tesla: Man Out of Time_ | Margaret Cheney | [Amazon](https://www.amazon.com/dp/0743215362?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/128529) | 3.79 | 2870
+1-D-14 | _NBC: America's Network_ | Michele Hilmes |  \| [Goodreads](https://www.goodreads.com/book/show/1526753) | 3.78 | 6
+2-A-4 | _Alan Turing: The Enigma_ | Andrew Hodges | [Amazon](https://www.amazon.com/dp/0671492071?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1043189) | 3.78 | 15
+2-A-27 | _Robert Maxwell, Israel's Superspy: The Life and Murder of a Media Mogul_ | Martin Dillon;Gordon Thomas | [Amazon](https://www.amazon.com/dp/B01FIZQJ4C?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/541687) | 3.78 | 39
+2-B-11 | _Inventing The Movies: Hollywood's Epic Battle Between Innovation And The Status Quo, From Thomas Edison To Steve Jobs_ | Scott Kirsner | [Amazon](https://www.amazon.com/dp/1438209991?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4348643) | 3.78 | 9
+3-B-13 | _Schulz and Peanuts: A Biography_ | David Michaelis | [Amazon](https://www.amazon.com/dp/0060937998?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/195218) | 3.78 | 2930
+3-D-30 | _Odyssey: Pepsi to Apple... a Journey of Adventure, Ideas and the Future_ | John Sculley | [Amazon](https://www.amazon.com/dp/0060915277?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/572025) | 3.78 | 10
+4-A-7 | _Eniac: The Triumphs and Tragedies of the World's First Computer_ | Scott McCartney | [Amazon](https://www.amazon.com/dp/0802713483?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2230010) | 3.78 | 31
+4-B-21 | _The Dinner Club (Bulldog Drummond)_ | Sapper, H. C. McNeile |  \| [Goodreads](https://www.goodreads.com/book/show/2963520) | 3.78 | 5
+4-E-7 | _Extreme Programming Applied: Playing to Win_ | Ken Auer,  Roy Miller | [Amazon](https://www.amazon.com/dp/0201616408?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18174) | 3.78 | 37
+4-F-17 | _From Edison to Enron: The Business of Power and What It Means for the Future of Electricity_ | Richard Munson |  \| [Goodreads](https://www.goodreads.com/book/show/32907) | 3.78 | 37
+5-B-14 | _Information Theory (Dover Books on Mathematics)_ | Robert B. Ash | [Amazon](https://www.amazon.com/dp/0486665216?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1568589) | 3.78 | 32
+7-C-13 | _Mac OS X Bible_ | Samuel A. Litt , Thomas Clancy Jr. , Warren G. Gottlieb , Douglas B. Heyman | [Amazon](https://www.amazon.com/dp/0764579177?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/169027) | 3.78 | 9
+7-E-12 | _The Definitive Guide to Apache mod_rewrite (Definitive Guides (Hardcover))_ | Rich Bowen | [Amazon](https://www.amazon.com/dp/1590595610?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/354579) | 3.78 | 18
+8-C-9 | _Wedding Of The Waters: The Erie Canal And The Making Of A Great Nation_ | Peter L. Bernstein | [Amazon](https://www.amazon.com/dp/B000OZ28MO?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/249243) | 3.78 | 257
+1-A-20 | _MICROSOFT SECRETS: How the World's Most Powerful Software Company Creates Technology, Shapes Markets, and Manages People_ | Michael A. Cusumano | [Amazon](https://www.amazon.com/dp/0028740483?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1146081) | 3.77 | 76
+1-B-11 | _The First Lady of Hollywood: A Biography of Louella Parsons_ | Samantha Barbas |  \| [Goodreads](https://www.goodreads.com/book/show/72545) | 3.77 | 22
+1-E-34 | _Postmortems from Game Developer: Insights from the Developers of Unreal Tournament, Black and White, Age of Empires, and Other Top-Selling Games_ | Austin Grossman | [Amazon](https://www.amazon.com/dp/1578202140?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/85001) | 3.77 | 918
+2-A-16 | _Beneath Mulholland: Thoughts on Hollywood and Its Ghosts_ | Thomson, David | [Amazon](https://www.amazon.com/dp/B010WFFB0G?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2049987) | 3.77 | 6
+2-E-6 | _The View From the Bridge: Memories of Star Trek and a Life in Hollywood_ | Nicholas Meyer | [Amazon](https://www.amazon.com/dp/067002130X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6440148) | 3.77 | 354
+3-E-4 | _A Fiery Peace in a Cold War_ | Neil Sheehan | [Amazon](https://www.amazon.com/dp/B00Y344ENI?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6377338) | 3.77 | 503
+4-C-24 | _UML Distilled: A Brief Guide to the Standard Object Modeling Language_ | Martin Fowler | [Amazon](https://www.amazon.com/dp/0321193687?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/85001) | 3.77 | 918
+4-D-11 | _Algorithms in Java, Parts 1-4 (3rd Edition)_ | Robert Sedgewick | [Amazon](https://www.amazon.com/dp/0201361205?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/968547) | 3.77 | 17
+4-D-25 | _Algorithms in Java, Parts 1-4_ | Robert Sedgewick, Michael Schidlowsky |  \| [Goodreads](https://www.goodreads.com/book/show/968547) | 3.77 | 17
+7-B-9 | _Writing GNU EMACs Extensions_ | Bob Glickstein | [Amazon](https://www.amazon.com/dp/B019TMB97W?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1639039) | 3.77 | 38
+2-F-4 | _New Media, 1740--1915_ | Lisa Gitelman, Geoffrey B. Pingree | [Amazon](https://www.amazon.com/dp/0262572281?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/151650) | 3.76 | 20
+3-A-11 | _Me and Ted Against the World_ | Reese Schonfeld | [Amazon](https://www.amazon.com/dp/0060197463?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/581927) | 3.76 | 21
+3-A-14 | _The Highwaymen_ | Ken Auletta | [Amazon](https://www.amazon.com/dp/0679457380?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4833934) | 3.76 | 9
+3-B-16 | _You and Me, Babe_ | Chuck Barris |  \| [Goodreads](https://www.goodreads.com/book/show/537259) | 3.76 | 3
+3-B-26 | _Hit and Run: How Jon Peters and Peter Guber took Sony for a ride in Hollywood_ | Nancy Griffin and Kim Masters | [Amazon](https://www.amazon.com/dp/0684809311?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/324915) | 3.76 | 267
+3-D-21 | _Renegades of the Empire: How Three Software Warriors Started a Revolution Behind the Walls of Fortress Microsoft_ | Michael Drummond | [Amazon](https://www.amazon.com/dp/0609604163?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/990785) | 3.76 | 38
+3-E-28 | _John Von Neumann: The Scientific Genius Who Pioneered the Modern Computer, Game Theory, Nuclear Deterrence, and Much More_ | Norman MacRae | [Amazon](https://www.amazon.com/dp/082182676X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/693795) | 3.76 | 70
+3-F-4 | _oPtion$ - The Secret Life of Steve Jobs_ | Fake Steve Jobs | [Amazon](https://www.amazon.com/dp/0306815842?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1110713) | 3.76 | 368
+4-C-8 | _Pattern-Oriented Software Architecture Volume 3: Patterns for Resource Management_ | Michael Kircher, Prashant Jain |  \| [Goodreads](https://www.goodreads.com/book/show/8256128) | 3.76 | 1
+5-A-23 | _John Von Neumann: The Scientific Genius Who Pioneered the Modern Computer, Game Theory, Nuclear Deterrence, and Much More_ | Norman MacRae |  \| [Goodreads](https://www.goodreads.com/book/show/693795) | 3.76 | 70
+5-A-26 | _Idea Man: A Memoir by the Cofounder of Microsoft_ | Paul Allen | [Amazon](https://www.amazon.com/dp/1591845378?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10139649) | 3.76 | 2246
+5-D-15 | _Joe Wilson and the Creation of Xerox_ | Charles D. Ellis, Anne M. Mulcahy |  \| [Goodreads](https://www.goodreads.com/book/show/62522) | 3.76 | 17
+7-B-15 | _Linux Cookbook: Practical Advice for Linux System Administrators_ | Carla Schroder | [Amazon](https://www.amazon.com/dp/0596006403?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/788762) | 3.76 | 37
+8-D-6 | _At Work with Thomas Edison: 10 Business Lessons from America's Greatest Innovator_ | Blaine McCormick | [Amazon](https://www.amazon.com/dp/1891984357?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/749139) | 3.76 | 21
+1-A-11 | _Ripped: How the Wired Generation Revolutionized Music_ | Greg Kot | [Amazon](https://www.amazon.com/dp/B019TMHK0M?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6240268) | 3.75 | 630
+1-C-4 | _My Paper Chase: True Stories of Vanished Times_ | Harold Evans | [Amazon](https://www.amazon.com/dp/B010EVR3FY?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6567378) | 3.75 | 127
+2-E-2 | _Rickles' Book: A Memoir_ | Don Rickles, David Ritz | [Amazon](https://www.amazon.com/dp/0743293061?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/740132) | 3.75 | 819
+2-E-14 | _The Long Embrace: Raymond Chandler and the Woman He Loved_ | Judith Freeman | [Amazon](https://www.amazon.com/dp/0375423516?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/357594) | 3.75 | 178
+3-D-8 | _The End of Cheap China_ | Shaun Rein_ | [Amazon](https://www.amazon.com/dp/1118926803?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/12786013) | 3.75 | 173
+3-F-16 | _A History of the Personal Computer: The People and the Technology_ | Roy A. Allan | [Amazon](https://www.amazon.com/dp/0968910807?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/197146) | 3.75 | 4
+4-A-18 | _The First Computers--History and Architectures (History of Computing)_ | Ral Rojas (Editor), Ulf Hashagen | [Amazon](https://www.amazon.com/dp/0262681374?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2164898) | 3.75 | 12
+4-C-5 | _Pattern Languages of Program Design 2_ | John M. Vlissides, James O. Coplien |  \| [Goodreads](https://www.goodreads.com/book/show/84992) | 3.75 | 20
+5-A-17 | _Windows 7: The Definitive Guide: The Essential Resource for Professionals and Power Users_ | William R. Stanek | [Amazon](https://www.amazon.com/dp/0596800975?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7023249) | 3.75 | 16
+5-C-27 | _Broken Genius: The Rise and Fall of William Shockley, Creator of the Electronic Age (Macmillan Science)_ | J. Shurkin |  \| [Goodreads](https://www.goodreads.com/book/show/537597) | 3.75 | 55
+7-B-28 | _From Bash to Z Shell: Conquering the Command Line_ | Oliver Kiddle, Peter Stephenson, Jerry Peek | [Amazon](https://www.amazon.com/dp/1590593766?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/172313) | 3.75 | 56
+7-B-31 | _Practical Unix & Internet Security, 3rd Edition_ | Simson Garfinkel, Gene Spafford, Alan Schwartz | [Amazon](https://www.amazon.com/dp/0596003234?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/618325) | 3.75 | 143
+8-D-20 | _Electric Universe: How Electricity Switched on the Modern World_ | David Bodanis | [Amazon](https://www.amazon.com/dp/0307335984?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2803) | 3.75 | 743
+2-D-27 | _Rebels on the Backlot: Six Maverick Directors and How They Conquered the Hollywood Studio System_ | Sharon Waxman | [Amazon](https://www.amazon.com/dp/0060540184?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/105701) | 3.74 | 544
+4-E-29 | _Agile and Iterative Development: A Manager's Guide_ | Craig Larman |  \| [Goodreads](https://www.goodreads.com/book/show/1229810) | 3.74 | 234
+7-D-7 | _Microsoftå Windowså XP Inside Out_ | Ed Bott,  Carl Siechert,  Craig Stinson | [Amazon](https://www.amazon.com/dp/073562044X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/447699) | 3.74 | 22
+8-D-23 | _The Merchant of Power: Sam Insull, Thomas Edison, and the Creation of the Modern Metropolis_ | John F. Wasik | [Amazon](https://www.amazon.com/dp/023060952X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/511825) | 3.74 | 34
+8-E-12 | _A Life Decoded: My Genome: My Life_ | J. Craig Venter | [Amazon](https://www.amazon.com/dp/0670063584?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1865671) | 3.74 | 509
+1-B-5 | _Wayward Reporter: The Life of A. J. Liebling_ | Raymond A. Sokolov | [Amazon](https://www.amazon.com/dp/0060140615?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/944256) | 3.73 | 0
+1-D-11 | _The Television History Book (Television, Media & Cultural Studies)_ | Michele Hilmes | [Amazon](https://www.amazon.com/dp/0851709885?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1774001) | 3.73 | 10
+2-F-14 | _True Genius: The Life and Science of John Bardeen: The Only Winner of Two Nobel Prizes in Physics_ | Vicki Daitch, Lillian Hoddeson | [Amazon](https://www.amazon.com/dp/0309095115?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/735744) | 3.73 | 26
+4-A-5 | _Closing the Innovation Gap: Reigniting the Spark of Creativity in a Global Economy_ | Judy Estrin | [Amazon](https://www.amazon.com/dp/0071499873?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3581576) | 3.73 | 39
+4-A-27 | _Codebreakers: The Inside Story of Bletchley Park_ | F. H. Hinsley (Editor), Alan Stripp | [Amazon](https://www.amazon.com/dp/0192801325?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/29609) | 3.73 | 223
+4-D-4 | _Evolutionary Game Theory_ | J_rgen W. Weibull |  \| [Goodreads](https://www.goodreads.com/book/show/770950) | 3.73 | 15
+4-F-5 | _JUNOS Cookbook: Time-Saving Techniques for JUNOS Software Configuration_ | Aviva Garrett | [Amazon](https://www.amazon.com/dp/0596100140?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/570722) | 3.73 | 15
+4-F-30 | _The First $20 Million Is Always the Hardest: A Silicon Valley Novel_ | Po Bronson | [Amazon](https://www.amazon.com/dp/0679456996?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1068178) | 3.73 | 33
+5-B-10 | _The Race for Perfect: Inside the Quest to Design the Ultimate Portable Computer_ | Steve Hamm |  \| [Goodreads](https://www.goodreads.com/book/show/3598289) | 3.73 | 10
+5-B-17 | _Antipatterns: Managing Software Organizations and People, Second Edition (Applied Software Engineering Series)_ | Colin J. Neill, Philip A. Laplante, Joanna F. DeFranco | [Amazon](https://www.amazon.com/dp/1439861862?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10494286) | 3.73 | 11
+5-E-29 | _Stealing Time: Steve Case, Jerry Levin, and the Collapse of AOL Time Warner_ | Alec Klein | [Amazon](https://www.amazon.com/dp/074325984X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/203611) | 3.73 | 44
+7-B-2 | _Linux in a Windows World: Leverage Linux to Make Windows More Secure, Responsive & Affordable_ | Roderick W Smith | [Amazon](https://www.amazon.com/dp/0596007582?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/68433) | 3.73 | 11
+7-E-29 | _Lucene in Action, Second Edition: Covers Apache Lucene 3.0_ | Michael McCandless,  Erik Hatcher, Otis Gospodnetic | [Amazon](https://www.amazon.com/dp/1933988177?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/22131010) | 3.73 | 11
+8-A-25 | _The Men Who Would Be King: An Almost Epic Tale of Moguls, Movies, and a Company Called DreamWorks_ | Nicole LaPorte | [Amazon](https://www.amazon.com/dp/0547134703?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7460370) | 3.73 | 936
+1-D-6 | _The Columbia History of American Television (Columbia Histories of Modern American Life)_ | Gary Edgerton | [Amazon](https://www.amazon.com/dp/0231121644?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2533659) | 3.72 | 15
+1-D-18 | _When Television Was Young: The Inside Story with Memories by Legends of the Small Screen_ | Ed McMahon, David Fisher | [Amazon](https://www.amazon.com/dp/1401603270?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1599544) | 3.72 | 21
+2-F-10 | _Beautiful Code: Leading Programmers Explain How They Think (Theory in Practice )_ | Andy Oram, Greg Wilson | [Amazon](https://www.amazon.com/dp/0596510047?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/405790) | 3.72 | 1222
+4-E-13 | _Tempo: timing, tactics and strategy in narrative-driven decision-making_ | Venkatesh Guru Rao | [Amazon](https://www.amazon.com/dp/0982703007?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10984768) | 3.72 | 111
+4-E-14 | _Tempo: timing, tactics and strategy in narrative-driven decision-making_ | Venkatesh Guru Rao | [Amazon](https://www.amazon.com/dp/0982703007?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10984768) | 3.72 | 111
+4-E-15 | _Tempo: timing, tactics and strategy in narrative-driven decision-making_ | Venkatesh Guru Rao | [Amazon](https://www.amazon.com/dp/0982703007?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10984768) | 3.72 | 111
+2-B-10 | _The Agency: William Morris and the Hidden History of Show Business_ | Frank Rose | [Amazon](https://www.amazon.com/dp/0887307493?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/964219) | 3.71 | 58
+2-E-12 | _The World and Its Double: The Life and Work of Otto Preminger_ | Chris Fujiwara | [Amazon](https://www.amazon.com/dp/086547995X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2461420) | 3.71 | 13
+4-D-23 | _A Little Java, A Few Patterns_ | Matthias Felleisen, Daniel P. Friedman | [Amazon](https://www.amazon.com/dp/0262561158?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/470776) | 3.71 | 50
+5-B-18 | _World Without Mind: The Existential Threat of Big Tech_ | Franklin Foer | [Amazon](https://www.amazon.com/dp/1101981113?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/34274961) | 3.71 | 393
+5-E-11 | _Comcasted: How Ralph And Brian Roberts Took Over America's Tv, One Deal At A Time_ | Joseph N. Distefano | [Amazon](https://www.amazon.com/dp/0940159821?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1596238) | 3.71 | 7
+7-C-20 | _IT Architectures and Middleware: Strategies for Building Large, Integrated Systems_ | Chris Britton | [Amazon](https://www.amazon.com/dp/0201709074?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1877522) | 3.71 | 8
+8-D-7 | _Edison and the Business of Innovation (Johns Hopkins Studies in the History of Technology)_ | Andr_ Millard | [Amazon](https://www.amazon.com/dp/0801847303?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2634073) | 3.71 | 6
+1-A-30 | _Sunburst: The Ascent of Sun Microsystems_ | Mark Hall, John Barry | [Amazon](https://www.amazon.com/dp/0809239892?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3860925) | 3.70 | 8
+1-C-3 | _All the News Unfit to Print: How Things Were... and How They Were Reported_ | Eric Burns | [Amazon](https://www.amazon.com/dp/0470405236?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6437530) | 3.70 | 29
+2-A-24 | _The Golden Age of Cinema: Hollywood, 1929-1945_ | Richard Jewell | [Amazon](https://www.amazon.com/dp/1405163739?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2111398) | 3.70 | 41
+2-D-30 | _Once You're Lucky, Twice You're Good_ | Sarah Lacy | [Amazon](https://www.amazon.com/dp/B001JQ1634?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2288436) | 3.70 | 340
+4-C-7 | _Pattern-Oriented Software Architecture Volume 2: Patterns for Concurrent and Networked Objects_ | Douglas C. Schmidt, Hans Rohnert |  \| [Goodreads](https://www.goodreads.com/book/show/85030) | 3.70 | 63
+4-C-21 | _Object Design: Roles, Responsibilities, and Collaborations_ | Rebecca Wirfs-Brock, Alan McKean |  \| [Goodreads](https://www.goodreads.com/book/show/179204) | 3.70 | 74
+4-E-23 | _Computer Networks and Internets_ | Douglas E. Comer | [Amazon](https://www.amazon.com/dp/0136061273?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4407038) | 3.70 | 56
+4-E-24 | _Invisible Engines: How Software Platforms Drive Innovation and Transform Industries_ | David S. Evans, Andrei Hagiu, Richard Schmalensee | [Amazon](https://www.amazon.com/dp/0262550687?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3646) | 3.70 | 30
+4-E-31 | _Visualizing Data: Exploring and Explaining Data with the Processing Environment_ | Ben Fry |  \| [Goodreads](https://www.goodreads.com/book/show/2112788) | 3.70 | 313
+5-D-11 | _Crystal Fire_ | Jordan Dane |  \| [Goodreads](https://www.goodreads.com/book/show/17679545) | 3.70 | 51
+3-F-3 | _West of Eden: The End of Innocence at Apple Computer_ | Frank Rose | [Amazon](https://www.amazon.com/dp/0670812781?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2480414) | 3.69 | 31
+3-F-13 | _Almost Perfect How a Brunch of Regular Guys Built WordPerfect Corporation_ | W. E. Pete Peterson | [Amazon](https://www.amazon.com/dp/0788199919?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2091881) | 3.69 | 58
+4-A-33 | _Dreaming in Code: Two Dozen Programmers, Three Years, 4,732 Bugs, and One Quest for Transcendent Software_ | Scott Rosenberg | [Amazon](https://www.amazon.com/dp/1400082471?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/32475) | 3.69 | 2064
+5-C-8 | _Moths to the Flame: The Seductions of Computer Technology_ | Gregory J.E. Rawlins | [Amazon](https://www.amazon.com/dp/0262680971?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2660816) | 3.69 | 9
+5-E-24 | _Softwar: An Intimate Portrait of Larry Ellison and Oracle_ | Matthew Symonds,  Larry Ellison |  \| [Goodreads](https://www.goodreads.com/book/show/281123) | 3.69 | 170
+7-E-14 | _Jakarta Commons Cookbook: Open Source Solutions to Java Development Problems_ | Timothy M. O'Brien | [Amazon](https://www.amazon.com/dp/059600706X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1308861) | 3.69 | 13
+8-C-1 | _Jay Cooke's Gamble: The Northern Pacific Railroad, the Sioux, and the Panic of 1873_ | M. John Lubetkin | [Amazon](https://www.amazon.com/dp/0806144688?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1109378) | 3.69 | 10
+8-E-21 | _The Honourable Company_ | John Keay | [Amazon](https://www.amazon.com/dp/0006380727?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/174502) | 3.69 | 258
+1-C-14 | _Thunderstruck_ | Erik Larson | [Amazon](https://www.amazon.com/dp/B00OHX1S5C?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/40067) | 3.68 | 25847
+2-D-18 | _A Pound of Flesh: Perilous Tales of How to Produce Movies in Hollywood_ | Art Linson | [Amazon](https://www.amazon.com/dp/0802115438?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/545155) | 3.68 | 1
+3-A-5 | _Master of the Game_ | Connie Bruck | [Amazon](https://www.amazon.com/dp/0671725742?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/100789) | 3.68 | 48
+3-B-23 | _Confessions of a Dangerous Mind: An Unauthorized Autobiography__ | Chuck Barris | [Amazon](https://www.amazon.com/dp/0786888083?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/87578) | 3.68 | 163
+3-E-2 | _Nano. the Emerging Science of Naontechnology: Remaking the World-Molecule By Molecule_ | Ed Regis | [Amazon](https://www.amazon.com/dp/B00P7BJPAS?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4563992) | 3.68 | 8
+7-D-8 | _Windows Vista Inside Out_ | Ed Bott,  Carl Siechert,  Craig Stinson | [Amazon](https://www.amazon.com/dp/0735622701?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/97765) | 3.68 | 25
+8-D-24 | _AC/DC: The Savage Tale of the First Standards War_ | Tom McNichol | [Amazon](https://www.amazon.com/dp/0787982679?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/880945) | 3.68 | 454
+1-A-5 | _The Television Will be Revolutionized_ | Amanda D. Lotz | [Amazon](https://www.amazon.com/dp/0814752209?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2683524) | 3.67 | 44
+1-A-31 | _Bootstrapping: Douglas Engelbart, Coevolution, and the Origins of Personal Computing_ | Thierry Bardini | [Amazon](https://www.amazon.com/dp/0804738718?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1196997) | 3.67 | 23
+1-B-2 | _Debating the Issues in Colonial Newspapers: Primary Documents on Events of the Period_ | David A. Copeland | [Amazon](https://www.amazon.com/dp/0313309825?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8513898) | 3.67 | 3
+2-E-10 | _The Trials of Lenny Bruce: The Fall and Rise of An American Icon_ | Ronald K. L. Collins, David M. Skover | [Amazon](https://www.amazon.com/dp/1570719861?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/950300) | 3.67 | 135
+3-A-4 | _Empire: William S. Paley and the Making of CBS_ | Lewis J. Paper | [Amazon](https://www.amazon.com/dp/0312005911?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2114109) | 3.67 | 8
+3-A-6 | _Rupert Murdoch_ | Neil Chenoweth | [Amazon](https://www.amazon.com/dp/0609610384?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/902852) | 3.67 | 20
+3-A-7 | _Rupert Murdoch_ | Neil Chenoweth |  \| [Goodreads](https://www.goodreads.com/book/show/18416281) | 3.67 | 0
+3-A-17 | _The Barry Diller Story: The Life and Times of America's Greatest Entertainment Mogul_ | George Mair | [Amazon](https://www.amazon.com/dp/0471130826?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1203883) | 3.67 | 14
+3-D-31 | _Man on the Flying Trapeze: The Life and Times of W.C. Fields_ | Simon Louvish_ | [Amazon](https://www.amazon.com/dp/0393318400?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/430342) | 3.67 | 15
+3-F-19 | _Steve Jobs and the NeXT Big Thing_ | Randall E. Stross | [Amazon](https://www.amazon.com/dp/0689121350?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/226316) | 3.67 | 55
+3-F-27 | _Burn Rate: How I Survived the Gold Rush Years on the Internet_ | Michael Wolff | [Amazon](https://www.amazon.com/dp/0684856212?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1077166) | 3.67 | 121
+5-B-1 | _Explorations in Quantum Computing_ | Colin P. Williams, Scott H. Clearwater | [Amazon](https://www.amazon.com/dp/038794768X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/374298) | 3.67 | 6
+5-B-26 | _Interface Culture: How New Technology Transforms the Way We Create & Communicate_ | Steven A. Johnson | [Amazon](https://www.amazon.com/dp/0465036805?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/36088) | 3.67 | 210
+7-C-19 | _del.icio.us Mashups_ | Brett O'Connor | [Amazon](https://www.amazon.com/dp/0470097760?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1068461) | 3.67 | 3
+7-D-1 | _Virtualization: From the Desktop to the Enterprise (Books for Professionals by Professionals)_ | Chris Wolf, Erick M. Halter | [Amazon](https://www.amazon.com/dp/1590594959?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/13309265) | 3.67 | 2
+8-A-14 | _Delivering Carrier Ethernet: Extending Ethernet Beyond the LAN_ | Abdul Kasim, Prasanna Adhikari, Nan Chen | [Amazon](https://www.amazon.com/dp/0071487476?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/343232) | 3.67 | 5
+1-C-11 | _Signor Marconis Magic Box: The Most Remarkable Invention of the 19th Century and the Amateur Inventor Whose Genius Sparked a Revolution_ | Gavin Weightman | [Amazon](https://www.amazon.com/dp/1422350436?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2184955) | 3.66 | 36
+3-E-7 | _What We Believe but Cannot Prove: Today's Leading Thinkers on Science in the Age of Certainty_ | John Brockman | [Amazon](https://www.amazon.com/dp/0060841818?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/109502) | 3.66 | 1236
+3-F-28 | _aol.com_ | Kara Swisher | [Amazon](https://www.amazon.com/dp/0812931912?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/203603) | 3.66 | 15
+5-C-14 | _Googled: The End of the World As We Know It_ | Ken Auletta | [Amazon](https://www.amazon.com/dp/1594202354?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6514908) | 3.66 | 2484
+7-B-24 | _Running Linux: A Distribution-Neutral Guide for Servers and Desktops_ | Matthias Kalle Dalheimer,  Matt Welsh | [Amazon](https://www.amazon.com/dp/0596007604?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1833212) | 3.66 | 119
+8-B-9 | _Hadoop In Action_ | Chuck Lam | [Amazon](https://www.amazon.com/dp/1521256608?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7284874) | 3.66 | 103
+8-C-10 | _William Mulholland and the rise of Los Angeles_ | Catherine Mulholland | [Amazon](https://www.amazon.com/dp/0520217241?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1557034) | 3.66 | 50
+8-C-12 | _William Mulholland and the Rise of Los Angeles_ | Catherine Mulholland |  \| [Goodreads](https://www.goodreads.com/book/show/1557034) | 3.66 | 50
+2-A-22 | _The Whole Equation: A History of Hollywood_ | David Thomson | [Amazon](https://www.amazon.com/dp/0375701540?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/41241) | 3.65 | 187
+2-D-3 | _Age of Context: Mobile, Sensors, Data and the Future of Privacy_ | Robert Scoble, Shel Israel | [Amazon](https://www.amazon.com/dp/1492348430?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18528692) | 3.65 | 625
+2-F-7 | _Doing Cultural Studies: The Story of the Sony Walkman_ | Paul du Gay, Stuart Hall, Linda Janes, Hugh Mackay, Keith Negus | [Amazon](https://www.amazon.com/dp/0761954023?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/603749) | 3.65 | 38
+3-A-22 | _Work in Progress_ | Michael D. Eisner  |  \| [Goodreads](https://www.goodreads.com/book/show/1843431) | 3.65 | 40
+4-E-9 | _Extreme Programming Installed_ | Ron Jeffries,  Ann Anderson, Chet Hendrickson | [Amazon](https://www.amazon.com/dp/0201708426?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/67834) | 3.65 | 119
+5-E-8 | _End of the Line: The Rise and Fall of AT&T_ | Leslie Cauley | [Amazon](https://www.amazon.com/dp/0743250257?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/251015) | 3.65 | 29
+7-A-13 | _Phone SDK Development (The Pragmatic Programmers)_ | Bill Dudney,  Christopher Adamson | [Amazon](https://www.amazon.com/dp/1934356255?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4811296) | 3.65 | 49
+2-D-23 | _The Man Who Heard Voices: Or, How M. Night Shyamalan Risked His Career on a Fairy Tale_ | Michael Bamberger | [Amazon](https://www.amazon.com/dp/1592402135?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/919276) | 3.64 | 236
+3-B-1 | _Bloomberg by Bloomberg_ | Michael R. Bloomberg | [Amazon](https://www.amazon.com/dp/0471208884?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/131533) | 3.64 | 354
+3-F-30 | _Tough Choices by Carly Fiorina_ | Carly Fiorina | [Amazon](https://www.amazon.com/dp/B00HTJPQQS?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/199756) | 3.64 | 785
+4-D-2 | _Algorithms of the Intelligent Web_ | Douglas McIlwraith,  Haralambos Marmanis,  Dmitry Babenko | [Amazon](https://www.amazon.com/dp/1617292583?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6464603) | 3.64 | 111
+4-D-13 | _Software Architecture Design Patterns in Java 1st Edition_ | Partha Kuchana | [Amazon](https://www.amazon.com/dp/0849321425?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/475631) | 3.64 | 11
+7-D-3 | _Windows XP Hacks, Second Edition_ | Preston Gralla | [Amazon](https://www.amazon.com/dp/0596009186?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/569671) | 3.64 | 12
+2-D-20 | _Set Up, Joke, Set Up, Joke_ | Rob Long | [Amazon](https://www.amazon.com/dp/0747547777?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/460001) | 3.63 | 60
+2-E-8 | _My Anecdotal Life_ | Carl Reiner | [Amazon](https://www.amazon.com/dp/0312311044?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/244323) | 3.63 | 300
+2-F-19 | _God and Golem, Inc.: A Comment on Certain Points where Cybernetics Impinges on Religion_ | Norbert Wiener | [Amazon](https://www.amazon.com/dp/0262730111?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18516492) | 3.63 | 0
+4-B-17 | _After Thought: The Computer Challenge To Human Intelligence_ | James Bailey | [Amazon](https://www.amazon.com/dp/0465007813?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1736503) | 3.63 | 16
+4-B-24 | _Casual Game Design: Designing Play for the Gamer in ALL of Us_ | Gregory Trefry | [Amazon](https://www.amazon.com/dp/0123749530?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7390490) | 3.63 | 36
+4-C-22 | _DEC Is Dead, Long Live DEC: The Lasting Legacy of Digital Equiment Corporation_ | Edgar H. Schein | [Amazon](https://www.amazon.com/dp/1458777677?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/19411077) | 3.63 | 2
+5-C-30 | _Planet Google: One Company's Audacious Plan To Organize Everything We Know_ | Randall Stross | [Amazon](https://www.amazon.com/dp/141654691X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3839314) | 3.63 | 691
+7-B-8 | _Learning GNU Emacs, Third Edition_ | Debra Cameron, James Elliott,  Marc Loy, Eric Raymond | [Amazon](https://www.amazon.com/dp/0596006489?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/860315) | 3.63 | 189
+8-A-13 | _Online Marketing Heroes: Interviews with 25 Successful Online Marketing Gurus_ | Michael Miller | [Amazon](https://www.amazon.com/dp/0470242043?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2830972) | 3.63 | 30
+1-D-12 | _The Other Parent: The Inside Story of the Media's Effect on Our Children_ | James P. Steyer,  Chelsea Clinton | [Amazon](https://www.amazon.com/dp/074340582X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3399566) | 3.62 | 11
+1-D-15 | _Same Time, Same Station: Creating American Television, 1948_1961_ | James L. Baughman |  \| [Goodreads](https://www.goodreads.com/book/show/753765) | 3.62 | 8
+2-C-16 | _Joseph P. Kennedy Presents: His Hollywood Years_ | Cari Beauchamp | [Amazon](https://www.amazon.com/dp/0571217362?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5031776) | 3.62 | 59
+3-F-21 | _Telecosm: How Infinite Bandwidth will Revolutionize Our World_ | George Gilder | [Amazon](https://www.amazon.com/dp/0684809303?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1225914) | 3.62 | 114
+5-A-20 | _The Gorilla Game: Picking Winners in High Technology_ | Geoffrey A. Moore, Paul Johnson | [Amazon](https://www.amazon.com/dp/0887309577?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1285026) | 3.62 | 104
+5-A-29 | _Jacquard's Web: How a Hand-Loom Led to the Birth of the Information Age_ | James Essinger | [Amazon](https://www.amazon.com/dp/0192805770?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/857534) | 3.62 | 84
+7-B-17 | _Linux Enterprise Cluster: Build a Highly Available Cluster with Commodity Hardware and Free Software_ | Karl Kopper | [Amazon](https://www.amazon.com/dp/1593270364?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/617241) | 3.62 | 8
+7-B-29 | _High Performance Linux Clusters with OSCAR, Rocks, OpenMosix, and MPI: A Comprehensive Getting-Started Guide (Nutshell Handbooks)_ | Joseph D Sloan | [Amazon](https://www.amazon.com/dp/0596005709?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/617242) | 3.62 | 8
+7-C-21 | _Beautiful Data: The Stories Behind Elegant Data Solutions_ | Toby Segaran,  Jeff Hammerbacher | [Amazon](https://www.amazon.com/dp/0596157118?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6492189) | 3.62 | 223
+7-E-8 | _Practical C Programming: Why Does 2+2 = 5986? (Nutshell Handbooks)_ | Steve Oualline | [Amazon](https://www.amazon.com/dp/1565923065?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/574686) | 3.62 | 172
+5-D-31 | _The Qualcomm Equation: How a Fledgling Telecom Company Forged a New Path to Big Profits and Market Dominance_ | Dave Mock | [Amazon](https://www.amazon.com/dp/0814409970?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/802476) | 3.61 | 28
+5-E-22 | _Sony vs Samsung: The Inside Story of the Electronics Giants' Battle For Global Supremacy_ | Sea-Jin Chang |  \| [Goodreads](https://www.goodreads.com/book/show/3348830) | 3.61 | 71
+7-D-14 | _Dreamweaver CS3: The Missing Manual_ | David Sawyer McFarland | [Amazon](https://www.amazon.com/dp/0596510438?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/893765) | 3.61 | 56
+2-A-18 | _The Coming of Sound_ | Douglas Gomery | [Amazon](https://www.amazon.com/dp/0415969018?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1084359) | 3.60 | 5
+2-B-6 | _Rosebud: The Story of Orson Welles_ | David Thomson | [Amazon](https://www.amazon.com/dp/0679772839?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/620573) | 3.60 | 257
+2-D-15 | _Never Coming to A Theater Near You_ | Kenneth Turan | [Amazon](https://www.amazon.com/dp/1586483498?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1450393) | 3.60 | 104
+3-A-20 | _The Keys to the Kingdom: How Michael Eisner Lost His Grip_ | Kim Masters | [Amazon](https://www.amazon.com/dp/0688174493?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/60240) | 3.60 | 107
+3-E-17 | _The Watson Dynasty: The Fiery Reign and Troubled Legacy of IBM's Founding Father and Son_ | Richard S. Tedlow | [Amazon](https://www.amazon.com/dp/0060014059?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/890951) | 3.60 | 2
+5-A-16 | _The Sourcebook of Parallel Computing (The Morgan Kaufmann Series in Computer Architecture and Design)_ | Jack Dongarra (Editor), Ian Foster (Editor), Geoffrey C. Fox (Editor), William Gropp (Editor), Ken Kennedy (Editor), Linda Torczon (Editor), Andy White (Editor) | [Amazon](https://www.amazon.com/dp/1558608710?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/819151) | 3.60 | 5
+7-B-27 | _Software Project Management_ | Bob Hughes,  Mike Cotterell | [Amazon](https://www.amazon.com/dp/0077122798?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8481874) | 3.60 | 55
+7-C-6 | _Mac OS X Panther Hacks: 100 Industrial Strength Tips & Tools_ | Rael Dornfest, James Duncan Davidson | [Amazon](https://www.amazon.com/dp/0596007183?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/991555) | 3.60 | 5
+1-A-2 | _Media and the American Mind: From Morse to McLuhan_ | Daniel J. Czitrom | [Amazon](https://www.amazon.com/dp/0807841072?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/225121) | 3.59 | 33
+1-A-32 | _ALL I REALLY NEED TO KNOW IN BUSINESS I LEARNED AT MICROSOFT: Insider Strategies to Help You Succeed_ | Julie Bick | [Amazon](https://www.amazon.com/dp/0671009133?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2345170) | 3.59 | 42
+2-A-8 | _Boulevard of Broken Dreams_ | Josh Lerner | [Amazon](https://www.amazon.com/dp/0691154538?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6828876) | 3.59 | 67
+4-F-9 | _Using Joomla: Building Powerful and Efficient Web Sites_ | Ron Severdia, Kenneth Crowder | [Amazon](https://www.amazon.com/dp/0596804946?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6840010) | 3.59 | 6
+5-D-28 | _The Automation: Vol. 1 of the Circo del Herrero Series (Volume 1)_ | The Automation: Vol. 1 of the Circo del Herrero Series (Volume 1) |  \| [Goodreads](https://www.goodreads.com/book/show/23277532) | 3.59 | 38
+7-A-6 | _The Men Who Stare at Goats_ | Jon Ronson | [Amazon](https://www.amazon.com/dp/1439181772?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6903597) | 3.59 | 519
+7-E-11 | _Apache Security_ | Ivan Ristic | [Amazon](https://www.amazon.com/dp/0596007248?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2001835) | 3.59 | 32
+8-A-24 | _Arcade Mania: The Turbo-charged World of Japan's Game Centers_ | Brian Ashcraft | [Amazon](https://www.amazon.com/dp/4770030789?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3960756) | 3.59 | 151
+8-E-11 | _The Battle for Las Vegas: The Law vs. The Mob_ | Dennis Griffin |  \| [Goodreads](https://www.goodreads.com/book/show/704332) | 3.58 | 183
+1-D-29 | _Chips and Change: How Crisis Reshapes the Semiconductor Industry_ | Clair Brown, Greg Linden | [Amazon](https://www.amazon.com/dp/0262013460?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7555422) | 3.57 | 13
+2-D-33 | _Amazon.com: Get Big Fast_ | Robert Spector | [Amazon](https://www.amazon.com/dp/0066620422?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/48844) | 3.57 | 183
+5-B-4 | _The Bit and the Pendulum: How the New Physics of Information is Revolutionizing Science_ | Tom Siegfried | [Amazon](https://www.amazon.com/dp/0471321745?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/721178) | 3.57 | 13
+5-C-33 | _Orson Welles (Life &Times)_ | Ben Walters |  \| [Goodreads](https://www.goodreads.com/book/show/1451776) | 3.57 | 7
+5-D-27 | _Inside Cisco IOS Software Architecture (CCIE Professional Development Series)_ | Vijay Bollapragada, Russ White, Curtis Murphy | [Amazon](https://www.amazon.com/dp/1587058162?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/961810) | 3.57 | 12
+7-B-20 | _Learning Red Hat Enterprise Linux and Fedora_ | Bill McCarty | [Amazon](https://www.amazon.com/dp/059600589X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1025291) | 3.57 | 7
+2-D-16 | _What Just Happened?: Bitter Hollywood Tales from the Front Line_ | Art Linson | [Amazon](https://www.amazon.com/dp/0802143385?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/19132139) | 3.56 | 9
+5-D-34 | _The God Effect: Quantum Entanglement, Science's Strangest Phenomenon_ | Brian Clegg | [Amazon](https://www.amazon.com/dp/031255530X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/767464) | 3.56 | 175
+7-B-14 | _Wicked Cool Shell Scripts_ | Dave Taylor | [Amazon](https://www.amazon.com/dp/1593270127?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/164232) | 3.56 | 66
+1-E-? | _A New Kind of Science_ | Stephen Wolfram | [Amazon](https://www.amazon.com/dp/1579550088) \| [Goodreads](https://www.goodreads.com/book/show/238558) | 3.55 | 1652
+2-D-5 | _Tales From Development Hell: The Greatest Movies Never Made?_ | David Hughes | [Amazon](https://www.amazon.com/dp/0857687239?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/11959547) | 3.55 | 497
+2-F-8 | _Unlocking Android_ | Frank Ableson Author, Charlie Collins,  Robi Sen | [Amazon](https://www.amazon.com/dp/1933988673?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4297991) | 3.55 | 18
+3-B-20 | _Chaplin: A Life_ | Stephen Weissman | [Amazon](https://www.amazon.com/dp/1559708921?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5290224) | 3.55 | 135
+3-C-29 | _Twitter API: Up and Running: Learn How to Build Applications with the Twitter API_ | Kevin Makice | [Amazon](https://www.amazon.com/dp/0596154615?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6190265) | 3.55 | 19
+4-A-30 | _The Accidental Investment Banker: Inside the Decade that Transformed Wall Street_ | Jonathan A. Knee |  \| [Goodreads](https://www.goodreads.com/book/show/127628) | 3.55 | 349
+5-E-12 | _Broadbandits: Inside the $750 Billion Telecom Heist_ | Om P. Malik,  Om Malik | [Amazon](https://www.amazon.com/dp/0471434051?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/941588) | 3.55 | 26
+7-C-7 | _The Old Iron Road: An Epic of Rails, Roads, and the Urge to Go West_ | David Haward Bain | [Amazon](https://www.amazon.com/dp/B01K93B3XA?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/336224) | 3.55 | 3
+8-D-17 | _Executioner's Current: Thomas Edison, George Westinghouse, and the Invention of the Electric Chair_ | Richard Moran | [Amazon](https://www.amazon.com/dp/0375410597?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1176338) | 3.55 | 40
+8-D-18 | _Executioner's Current: Thomas Edison, George Westinghouse, and the Invention of the Electric Chair_ | Richard Moran | [Amazon](https://www.amazon.com/dp/B01N0BR7BY?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/313163) | 3.55 | 10
+1-A-6 | _Life After Television: The Coming Transformation of Media and American Life_ | George Gilder | [Amazon](https://www.amazon.com/dp/B002JSEUQG?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2023682) | 3.54 | 4
+1-A-7 | _Life After Television: The Coming Transformation of Media and American Life_ | George Gilder | [Amazon](https://www.amazon.com/dp/0393311589?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1976908) | 3.54 | 15
+3-A-10 | _Clash of the Titans_ | Richard Hack | [Amazon](https://www.amazon.com/dp/1893224600?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/510771) | 3.54 | 28
+4-F-12 | _Top Secret Tourism: Your Travel Guide to Germ Warfare Laboratories, Clandestine Aircraft Bases and Other Places in the United States You're Not Supposed to Know About_ | Harry Helms | [Amazon](https://www.amazon.com/dp/1932595236?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/726040) | 3.54 | 61
+1-A-4 | _Media Technology and Society: A History From the Telegraph to the Internet_ | Brian Winston | [Amazon](https://www.amazon.com/dp/041514230X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4484535) | 3.53 | 3
+2-A-31 | _F'd Companies: Spectacular Dot-com Flameouts_ | Philip J. Kaplan | [Amazon](https://www.amazon.com/dp/1416577939?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/25147) | 3.53 | 104
+2-B-19 | _The Jack Welch Lexicon of Leadership: Over 250 Terms, Concepts, Strategies & Initiatives of the Legendary Leader_ | Jeffrey Krames | [Amazon](https://www.amazon.com/dp/0071381406?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5569) | 3.53 | 31
+3-F-32 | _F'd Companies: Spectacular Dot-com Flameouts_ | Philip J. Kaplan | [Amazon](https://www.amazon.com/dp/0743228626?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/25147) | 3.53 | 104
+4-C-3 | _Pattern Languages of Program Design 3 (v. 3)_ | Robert C. Martin, Dirk Riehle, Frank Buschmann | [Amazon](https://www.amazon.com/dp/0201310112?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/79774) | 3.53 | 19
+4-E-12 | _Pragmatic Unit Testing in Java with Junit_ | Andy Hunt, Dave Thomas | [Amazon](https://www.amazon.com/dp/0974514012?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/89199) | 3.53 | 156
+4-F-29 | _Silicon Valley Fever_ | Out Of Print | [Amazon](https://www.amazon.com/dp/0465078214?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/721516) | 3.53 | 9
+7-D-10 | _The Essential Guide to Dreamweaver CS3 with CSS, Ajax, and PHP (Friends of Ed Adobe Learning Library)_ | David Powers | [Amazon](https://www.amazon.com/dp/1590598598?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1546234) | 3.53 | 15
+1-A-3 | _A Social History of the Media: From Gutenberg to the Internet_ | Peter Burke | [Amazon](https://www.amazon.com/dp/B01FIX7NNA?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/882097) | 3.52 | 85
+2-D-12 | _Bambi vs. Godzilla: On the Nature, Purpose, and Practice of the Movie Business_ | David Mamet | [Amazon](https://www.amazon.com/dp/1400034442?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/74201) | 3.52 | 825
+2-D-17 | _Shoot Out: Surviving Fame and (Mis)Fortune in Hollywood_ | Peter Bart, Peter Guber | [Amazon](https://www.amazon.com/dp/0399528881?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/324927) | 3.52 | 55
+3-A-16 | _Media Man: Ted Turner's Improbable Empire (Enterprise)_ | Ken Auletta | [Amazon](https://www.amazon.com/dp/0393327493?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1333724) | 3.52 | 26
+3-F-15 | _Priming the Pump: How TRS-80 Enthusiasts Helped Spark the PC Revolution_ | David Welsh, Theresa M. Welsh | [Amazon](https://www.amazon.com/dp/0979346800?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1659567) | 3.52 | 29
+4-F-24 | _The Daemon, the Gnu, and the Penguin_ | Peter H. Salus,  Jeremy C. Reed,  Jon Hall | [Amazon](https://www.amazon.com/dp/097903423X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5273962) | 3.52 | 19
+5-D-32 | _Say Everything: How Blogging Began, What It's Becoming, and Why It Matters_ | Scott Rosenberg |  \| [Goodreads](https://www.goodreads.com/book/show/6294828) | 3.52 | 155
+5-D-18 | _Revolutionaries at Sony: The Making of the Sony Playstation and the Visionaries Who Conquered the World of Video Games_ | Reiji Asakura | [Amazon](https://www.amazon.com/dp/0071355871?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1379119) | 3.51 | 35
+8-A-11 | _Jetpack Dreams: One Man's Up and Down (But Mostly Down) Search for the Greatest Invention That Never Was_ | Mac Montandon |  \| [Goodreads](https://www.goodreads.com/book/show/2780773) | 3.51 | 33
+8-E-10 | _Sharks in the Desert_ | John L. Smith | [Amazon](https://www.amazon.com/dp/1569802742?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/433847) | 3.51 | 43
+1-C-10 | _Listening to Radio, 1920-1950_ | Ray Barfield | [Amazon](https://www.amazon.com/dp/0275954927?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3976408) | 3.50 | 4
+1-C-15 | _Radio's America: The Great Depression and the Rise of Modern Mass Culture_ | Bruce Lenthall | [Amazon](https://www.amazon.com/dp/0226471926?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7786406) | 3.50 | 2
+2-A-23 | _In the Nick of Time: Motion Picture Sound Serials_ | William C. Cline | [Amazon](https://www.amazon.com/dp/078640471X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1845752) | 3.50 | 1
+2-C-3 | _Cecil B. DeMille and American Culture: The Silent Era_ | Sumiko Higashi | [Amazon](https://www.amazon.com/dp/0520085574?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1506478) | 3.50 | 6
+2-C-10 | _ONCE UPON A TIME IN HOLLYWOOD: Moviemaking, Con Games, and Murder in Glitter City_ | Rod Lurie | [Amazon](https://www.amazon.com/dp/0679435220?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1454390) | 3.50 | 10
+2-D-21 | _Sam Spiegel_ | Natasha Fraser- Cavassoni | [Amazon](https://www.amazon.com/dp/068483619X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6949441) | 3.50 | 3
+2-D-28 | _dot.bomb: My Days and Nights at an Internet Goliath_ | J. David Kuo | [Amazon](https://www.amazon.com/dp/0316507490?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7855222) | 3.50 | 10
+2-F-27 | _You Say You Want a Revolution : A Story of Information Age Politics_ | Mr. Reed Hundt, Reed E. Hundt | [Amazon](https://www.amazon.com/dp/0300083645?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/324962) | 3.50 | 8
+3-A-2 | _David Sarnoff: A Biography_ | Eugene Lyons | [Amazon](https://www.amazon.com/dp/B000OL6FPO?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1665374) | 3.50 | 2
+3-A-15 | _A Passion to Win_ | Sumner Redstone | [Amazon](https://www.amazon.com/dp/B00005LKUK?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1486118) | 3.50 | 57
+3-E-1 | _Revolution in Miniature: The History and Impact of Semiconductor Electronics_ | Ernest Braun, _Stuart MacDonald | [Amazon](https://www.amazon.com/dp/0521247012?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3872969) | 3.50 | 0
+4-A-19 | _From Whirlwind to MITRE: The R&D Story of The SAGE Air Defense Computer (History of Computing)_ | Kent C. Redmond, Thomas M. Smith | [Amazon](https://www.amazon.com/dp/0262182017?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2744477) | 3.50 | 10
+4-C-1 | _Pattern Languages of Program Design 4 (Software Patterns Series)_ | Brian Foote, Neil Harrison, Hans Rohnert | [Amazon](https://www.amazon.com/dp/0201433044?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/79775) | 3.50 | 10
+5-C-12 | _Inventing the Electronic Century: The Epic Story of the Consumer Electronics and Computer Industries, With a New Preface_ | Alfred D. Chandler Jr. |  \| [Goodreads](https://www.goodreads.com/book/show/577718) | 3.50 | 7
+5-D-25 | _The Ultimate Entrepreneur's Book: A Straight Talking Guide To Business Success And Personal Riches_ | Richard Dobbins |  \| [Goodreads](https://www.goodreads.com/book/show/668706) | 3.50 | 2
+5-E-28 | _Optical Illusions: Lucent and the Crash of Telecom_ | Lisa Endlich | [Amazon](https://www.amazon.com/dp/0743226674?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/438022) | 3.50 | 18
+7-A-10 | _iPhone Advanced Projects (Apress Series of iPhone Projects)_ | Joachim Bondo | [Amazon](https://www.amazon.com/dp/1430224037?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6814977) | 3.50 | 6
+7-B-1 | _Red Hat Fedora Linux 3 Bible [With DVD]_ | Christopher Negus |  \| [Goodreads](https://www.goodreads.com/book/show/3690337) | 3.50 | 4
+7-C-18 | _Programming Windows Azure: Programming the Microsoft Cloud_ | Sriram Krishnan | [Amazon](https://www.amazon.com/dp/0596801971?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7781193) | 3.50 | 16
+2-A-15 | _Lost Hollywood_ | David Wallace | [Amazon](https://www.amazon.com/dp/0312288638?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/607888) | 3.49 | 43
+2-E-33 | _Everything Bad is Good for You: How Today's Popular Culture is Actually Making Us Smarter_ | Steven Johnson | [Amazon](https://www.amazon.com/dp/1594481946?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/546039) | 3.49 | 212
+8-A-8 | _Survival City: Adventures Among the Ruins of Atomic America_ | Tom Vanderbilt | [Amazon](https://www.amazon.com/dp/1568983050?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/600462) | 3.49 | 66
+2-F-1 | _John von Neumann and the Origins of Modern Computing (History of Computing)_ | William Aspray | [Amazon](https://www.amazon.com/dp/0262518856?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/693796) | 3.48 | 19
+5-B-31 | _Network Power: The Social Dynamics of Globalization_ | David Singh Grewal | [Amazon](https://www.amazon.com/dp/0300112408?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3341556) | 3.48 | 22
+1-A-9 | _Sound Recording: The Life Story of a Technology_ | David L. Morton Jr. | [Amazon](https://www.amazon.com/dp/0801883989?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1009425) | 3.47 | 14
+2-D-22 | _The Triumph of the Thriller: How Cops, Crooks, and Cannibals Captured Popular Fiction_ | Patrick Anderson | [Amazon](https://www.amazon.com/dp/0345481232?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/115213) | 3.47 | 47
+2-F-20 | _Turing and the Computer: The Big Idea_ | Paul Strathern | [Amazon](https://www.amazon.com/dp/038549243X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1116635) | 3.47 | 69
+3-E-5 | _Soldiers of Reason: The RAND Corporation and the Rise of the American Empire_ | Alex Abella | [Amazon](https://www.amazon.com/dp/B012YWJ8MW?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6768480) | 3.47 | 9
+3-E-15 | _IBM Redux: Lou Gerstner and the Business Turnaround of the Decade_ | Doug Garr | [Amazon](https://www.amazon.com/dp/0887309437?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/679503) | 3.47 | 28
+4-F-21 | _America Calling: A Social History of the Telephone to 1940_ | Claude S. Fischer | [Amazon](https://www.amazon.com/dp/0520079337?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1578833) | 3.47 | 33
+5-B-30 | _Stealing MySpace: The Battle to Control the Most Popular Website in America_ | Julia Angwin | [Amazon](https://www.amazon.com/dp/1400066948?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5635215) | 3.47 | 166
+8-D-8 | _Edison on Innovation: 102 Lessons in Creativity for Business and Beyond_ | Alan Axelrod | [Amazon](https://www.amazon.com/dp/0787994596?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2873660) | 3.47 | 17
+1-A-21 | _The Microsoft Edge: Insider Strategies for Building Success_ | Julie Bick | [Amazon](https://www.amazon.com/dp/0671034146?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1737728) | 3.46 | 11
+1-A-28 | _Barbarians Led by Bill Gates by Jennifer Edstrom_ | Jennifer Edstrom;Marlin Elle | [Amazon](https://www.amazon.com/dp/B01K16KI3Q?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1526750) | 3.46 | 95
+2-E-5 | _Auto Focus: The Murder of Bob Crane by Robert Graysmith_ | Robert Graysmith | [Amazon](https://www.amazon.com/dp/0425189023?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/105769) | 3.46 | 118
+3-B-25 | _Everyone Else Must Fail: The Unvarnished Truth About Oracle and Larry Ellison_ | Karen Southwick | [Amazon](https://www.amazon.com/dp/0609610694?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/591922) | 3.46 | 23
+7-E-9 | _Apache: The Definitive Guide (3rd Edition)_ | Ben Laurie, Peter Laurie | [Amazon](https://www.amazon.com/dp/0596002033?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/354577) | 3.46 | 79
+3-A-8 | _Murdoch_ | William Shawcross | [Amazon](https://www.amazon.com/dp/0684830159?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/902842) | 3.45 | 48
+3-E-13 | _Breaking Windows: How Bill Gates Fumbled the Future of Microsoft_ | David Bank | [Amazon](https://www.amazon.com/dp/B010CKSFT0?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/517503) | 3.45 | 70
+7-D-15 | _Breaking Windows: How Bill Gates Fumbled the Future of Microsoft_ | David Bank | [Amazon](https://www.amazon.com/dp/1416573259?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/517503) | 3.45 | 70
+8-D-13 | _Edison: A Life of Invention_ | Paul Israel | [Amazon](https://www.amazon.com/dp/0471362700?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/749135) | 3.45 | 74
+1-A-18 | _How the Web Was Won_ | Paul Andrews | [Amazon](https://www.amazon.com/dp/0767900480?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/41627) | 3.44 | 24
+2-A-28 | _I Sing the Body Electronic: A Year with Microsoft on the Multimedia Frontier_ | Fred Moody | [Amazon](https://www.amazon.com/dp/B002K7I1FC?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2204593) | 3.44 | 9
+3-B-2 | _Mike Bloomberg: Money, Power, Politics_ | Joyce Purnick | [Amazon](https://www.amazon.com/dp/1586485776?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6722230) | 3.44 | 86
+7-A-25 | _Beginning Android (Beginning From Novice to Professional)_ | Mark Murphy | [Amazon](https://www.amazon.com/dp/1430224193?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6677016) | 3.44 | 17
+3-F-24 | _Where's My Jetpack? A Guide to the Amazing Science Fiction Future That Never Arrived_ | Daniel H. Wilson,_Ph.D. | [Amazon](https://www.amazon.com/dp/0786169214?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6004534) | 3.43 | 11
+1-A-8 | _The Chaos Scenario_ | Bob Garfield | [Amazon](https://www.amazon.com/dp/0984065105?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6589670) | 3.42 | 54
+4-C-4 | _Pattern Languages of Program Design_ | James O. Coplien, Douglas C. Schmidt |  \| [Goodreads](https://www.goodreads.com/book/show/79767) | 3.42 | 22
+4-D-6 | _Data Structures and Abstractions with Java (2nd Edition)_ | Frank M. Carrano | [Amazon](https://www.amazon.com/dp/013237045X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/27847) | 3.42 | 35
+1-A-19 | _The Microsoft Way: The Real Story Of How The Company Outsmarts Its Competition_ | Randall E. Stross | [Amazon](https://www.amazon.com/dp/020132797X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/578629) | 3.41 | 48
+1-A-23 | _Business the Bill Gates Way_ | Des Dearlove | [Amazon](https://www.amazon.com/dp/1841121487?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/41620) | 3.41 | 10
+7-E-38 | _The Computer: A Very Short Introduction_ | Darrel Ince | [Amazon](https://www.amazon.com/dp/0199586594?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/12941074) | 3.41 | 42
+1-B-4 | _Pulitzer_ | W.A. Swanberg | [Amazon](https://www.amazon.com/dp/068410587X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/815324) | 3.40 | 15
+2-A-6 | _Patterns for Parallel Programming_ | Timothy G. Mattson, Beverly A. Sanders,  Berna L. Massingill | [Amazon](https://www.amazon.com/dp/0321228111?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/85053) | 3.40 | 32
+4-F-15 | _The Grid: A Journey Through the Heart of Our Electrified World_ | Phillip F. Schewe | [Amazon](https://www.amazon.com/dp/030910260X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/495463) | 3.40 | 113
+4-F-26 | _ZOOM: The Global Race to Fuel the Car of the Future_ | Vijay Vaitheeswaran, Iain Carson | [Amazon](https://www.amazon.com/dp/044658004X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1913685) | 3.40 | 104
+7-E-27 | _The Book of Zope_ | Beehive | [Amazon](https://www.amazon.com/dp/1886411573?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/853033) | 3.40 | 5
+7-E-10 | _Apache Cookbook: Solutions and Examples for Apache Administrators_ | Rich Bowen, Ken Coar | [Amazon](https://www.amazon.com/dp/0596529945?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2370202) | 3.39 | 29
+8-E-7 | _Genuine Authentic: The Real Life of Ralph Lauren_ | Michael Gross | [Amazon](https://www.amazon.com/dp/0060199040?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2961848) | 3.39 | 5
+1-A-27 | _Betting It All The Technology Entrepreneurs_ | Michael Malone | [Amazon](https://www.amazon.com/dp/B0076LJE1M?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/767760) | 3.38 | 7
+2-A-7 | _Bricklin on Technology_ | Dan Bricklin | [Amazon](https://www.amazon.com/dp/0470402377?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6337143) | 3.38 | 13
+2-F-9 | _The Making of American Audiences: From Stage to Television, 1750-1990 (Cambridge Studies in the History of Mass Communication)_ | Richard Butsch | [Amazon](https://www.amazon.com/dp/0511619715?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1387347) | 3.38 | 8
+3-F-7 | _World War 3.0 : Microsoft and Its Enemies_ | Ken Auletta | [Amazon](https://www.amazon.com/dp/0375503668?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/469543) | 3.38 | 52
+8-A-12 | _Pro Android Games (Books for Professionals by Professionals)_ | Vladimir Silva | [Amazon](https://www.amazon.com/dp/1430226471?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7483653) | 3.38 | 13
+7-A-28 | _The iPhone Developer's Cookbook: Building Applications with the iPhone 3.0 SDK (2nd Edition)_ | Erica Sadun | [Amazon](https://www.amazon.com/dp/0321659570?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3427125) | 3.37 | 80
+7-A-29 | _Piloting Palm: The Inside Story of Palm, Handspring, and the Birth of the Billion-Dollar Handheld Industry_ | Andrea Butter, David Pogue | [Amazon](https://www.amazon.com/dp/0471089656?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3427125) | 3.37 | 80
+8-A-9 | _The iPhone Developer's Cookbook: Building Applications with the iPhone SDK_ | Erica Sadun | [Amazon](https://www.amazon.com/dp/0321555457?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3427125) | 3.37 | 80
+4-F-14 | _Power to the People_ | Vijay V. Vaitheeswaran | [Amazon](https://www.amazon.com/dp/B00E2RHM44?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/434277) | 3.36 | 44
+8-A-10 | _Android Application Development: Programming with the Google SDK_ | Rick Rogers, John Lombardo, Zigurd Mednieks,  G. Blake Meike | [Amazon](https://www.amazon.com/dp/0596521472?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5789012) | 3.36 | 19
+8-E-2 | _Dynasties: Fortunes and Misfortunes of the World's Great Family Businesses_ | David S. Landes | [Amazon](https://www.amazon.com/dp/0670033383?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/200841) | 3.36 | 110
+8-E-14 | _When the Mob Ran Vegas: Stories of Money, Mayhem and Murder_ | Steve Fischer | [Amazon](https://www.amazon.com/dp/0977065804?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/536259) | 3.36 | 387
+2-D-32 | _Twenty-one Dog Years: Doing Time at Amazon.com_ | Mike Daisey | [Amazon](https://www.amazon.com/dp/1841157651?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/493179) | 3.35 | 342
+4-B-20 | _Using Google App Engine: Building Web Applications_ | Charles Severance | [Amazon](https://www.amazon.com/dp/059680069X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6209792) | 3.34 | 36
+2-F-22 | _Android: A Programmer's Guide_ | J.F. DiMarzio | [Amazon](https://www.amazon.com/dp/0071599886?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3429845) | 3.33 | 9
+3-A-1 | _The General: David Sarnoff and the Rise of the Communications Industry_ | Kenneth Bilby | [Amazon](https://www.amazon.com/dp/006015568X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2341571) | 3.33 | 9
+4-E-3 | _Pragmatic Project Automation: How to Build, Deploy, and Monitor Java Apps_ | Mike Clark | [Amazon](https://www.amazon.com/dp/0974514039?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/89198) | 3.33 | 123
+7-C-7 | _Mac OS X Hacks: 100 Industrial-Strength Tips & Tricks_ | Rael Dornfest, Kevin Hemenway | [Amazon](https://www.amazon.com/dp/0596004605?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1038762) | 3.33 | 15
+8-E-20 | _We Blog: Publishing Online with Weblogs_ | Paul Bausch |  \| [Goodreads](https://www.goodreads.com/book/show/928475) | 3.33 | 9
+1-B-14 | _The Uncrowned King: The Sensational Rise of William Randolph Hearst_ | Kenneth Whyte | [Amazon](https://www.amazon.com/dp/1582434670?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5660131) | 3.32 | 51
+3-E-24 | _Perfect Enough: Carly Fiorina and the Reinvention of Hewlett-Packard_ | George Anders | [Amazon](https://www.amazon.com/dp/B01FJ162D8?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1218322) | 3.32 | 48
+7-E-22 | _Building Online Communities With Drupal, phpBB, and WordPress_ | Robert T. Douglass, Mike Little, Jared W. Smith | [Amazon](https://www.amazon.com/dp/1590595629?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/169043) | 3.32 | 37
+7-E-24 | _Embedding Perl in HTML with Mason_ | Dave Rolsky, Ken Williams | [Amazon](https://www.amazon.com/dp/0596002254?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/845507) | 3.32 | 17
+7-E-33 | _Professional Apache Tomcat_ | Vivek Chopra, Sing Li,  Jeff Genender | [Amazon](https://www.amazon.com/dp/0471753610?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/135442) | 3.32 | 19
+4-C-18 | _Antipatterns: Identification, Refactoring, and Management (Auerbach Series on Applied Software Engineering)_ | Phillip A. Laplante, Colin J. Neill | [Amazon](https://www.amazon.com/dp/0849329949?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/337303) | 3.31 | 16
+1-D-23 | _They'll Never Put That on the Air: An Oral History of Taboo-Breaking Comedy_ | Allan Neuwirth | [Amazon](https://www.amazon.com/dp/1581154178?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1038744) | 3.30 | 10
+5-E-3 | _Perot: An Unauthorized Biography_ | Todd Mason | [Amazon](https://www.amazon.com/dp/1556232365?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7506716) | 3.30 | 3
+1-D-27 | _Internet Alley: High Technology in Tysons Corner, 1945-2005_ | Paul E. Ceruzzi | [Amazon](https://www.amazon.com/dp/0262033747?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/3098844) | 3.29 | 11
+4-B-19 | _Embracing Insanity: Open Source Software Development (Other Sams)_ | Russell Pavlicek | [Amazon](https://www.amazon.com/dp/0672319896?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1833263) | 3.28 | 18
+3-D-3 | _Programming Google App Engine_ | Dan Sanderson | [Amazon](https://www.amazon.com/dp/059652272X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7244453) | 3.27 | 37
+4-D-22 | _Patterns in Java_ | Mark Grand | [Amazon](https://www.amazon.com/dp/0471258415?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6100704) | 3.27 | 15
+7-B-13 | _The Linux Cookbook, Second Edition_ | Michael Stutz | [Amazon](https://www.amazon.com/dp/1593270313?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1482714) | 3.26 | 24
+2-F-6 | _The Geeks of War: The Secretive Labs and Brilliant Minds Behind Tomorrow's Warfare Technologies_ | John Edwards | [Amazon](https://www.amazon.com/dp/0814408524?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/521481) | 3.24 | 15
+7-E-25 | _The Definitive Guide to Plone_ | Andy McKay | [Amazon](https://www.amazon.com/dp/1590593294?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/853017) | 3.24 | 17
+2-E-13 | _Peer-to-Peer : Harnessing the Power of Disruptive Technologies_ | Andy Oram | [Amazon](https://www.amazon.com/dp/059600110X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1171678) | 3.22 | 32
+5-D-2 | _Leonardo's Laptop: Human Needs and the New Computing Technologies_ | Ben Shneiderman | [Amazon](https://www.amazon.com/dp/0262692996?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/418881) | 3.22 | 63
+7-A-11 | _Palm webOS_ | Mitch Allen | [Amazon](https://www.amazon.com/dp/0596155255?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6386507) | 3.22 | 9
+2-C-13 | _City of Dreams: The Making and Remaking of Universal Pictures_ | Bernard F. Dick | [Amazon](https://www.amazon.com/dp/0813120160?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1470761) | 3.20 | 5
+4-E-10 | _iPhone Game Projects_ | PJ Cabrera, Joachim Bondo, Brian Greenstone | [Amazon](https://www.amazon.com/dp/1430222417?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6678115) | 3.19 | 16
+2-D-6 | _Category Killers: The Retail Revolution and Its Impact on Consumer Culture_ | Robert Spector | [Amazon](https://www.amazon.com/dp/1578519608?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/951466) | 3.18 | 22
+7-B-3 | _Linux Clustering: Building and Maintaining Linux Clusters_ | Charles Bookman | [Amazon](https://www.amazon.com/dp/1578702747?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1094278) | 3.17 | 6
+2-D-24 | _Ain't It Cool? Hollywood's Redheaded Stepchild Speaks Out_ | Mark Ebner, Paul Cullum, Harry Knowles | [Amazon](https://www.amazon.com/dp/0446679917?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/326168) | 3.16 | 41
+2-E-7 | _I Like It Better When You're Funny: Working in Television and Other Precarious Adventures_ | Charles Grodin | [Amazon](https://www.amazon.com/dp/0375507841?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/469238) | 3.16 | 38
+3-F-5 | _On the Firing Line: My 500 Days at Apple_ | Gil Amelio and William L. Simon | [Amazon](https://www.amazon.com/dp/0887309186?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/643880) | 3.15 | 48
+4-C-13 | _Software Factories: Assembling Applications with Patterns, Models, Frameworks, and Tools_ | Jack Greenfield, Steve Cook |  \| [Goodreads](https://www.goodreads.com/book/show/919163) | 3.15 | 26
+7-B-25 | _Setting up LAMP: Getting Linux, Apache, MySQL, and PHP Working Together_ | Eric Filson, Erick Rosebrock | [Amazon](https://www.amazon.com/dp/0782143377?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1051755) | 3.15 | 10
+2-C-14 | _The Fun Factory: The Keystone Film Company and the Emergence of Mass Culture_ | Rob King | [Amazon](https://www.amazon.com/dp/0520255380?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6309050) | 3.14 | 7
+4-F-2 | _iPhone Game Development_ | Paul Zirkle, Joe Hogue | [Amazon](https://www.amazon.com/dp/0596159854?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6678116) | 3.14 | 12
+8-E-19 | _The Business of Empire: The East India Company and Imperial Britain, 1756-1833_ | H.V. Bowen |  \| [Goodreads](https://www.goodreads.com/book/show/294726) | 3.14 | 7
+3-F-33 | _The Art of the Video Game_ | Josh Jenisch | [Amazon](https://www.amazon.com/dp/1594742774?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6057542) | 3.13 | 45
+3-A-9 | _The Man Who Owns the News: Inside the Secret World of Rupert Murdoch_ | Michael Wolff | [Amazon](https://www.amazon.com/dp/0767929527?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7630937) | 3.12 | 6
+3-B-15 | _Bad Grass Never Dies_ | Chuck Barris | [Amazon](https://www.amazon.com/dp/0786713798?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/537258) | 3.12 | 99
+7-A-27 | _iPhone Cool Projects_ | Wolfgang Ante, Gary Bennett, Benjamin Jackson, Neil Mix, Steven Peterson | [Amazon](https://www.amazon.com/dp/143022357X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6434882) | 3.12 | 8
+7-D-9 | _Pro Hadoop_ | Jason Venner | [Amazon](https://www.amazon.com/dp/1430219424?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6863676) | 3.12 | 16
+4-D-7 | _Data Structures in Java_ | Thomas A. Standish | [Amazon](https://www.amazon.com/dp/020130564X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2960177) | 3.11 | 9
+4-C-19 | _Prefactoring_ | Kenneth Pugh | [Amazon](https://www.amazon.com/dp/0596008740?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/866193) | 3.10 | 31
+3-E-18 | _Backfire: Carly Fiorina's High-Stakes Battle for the Soul of Hewlett-Packard_ | Peter Burrows | [Amazon](https://www.amazon.com/dp/0471267651?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/414335) | 3.09 | 22
+3-E-25 | _Obsolete: An Encyclopedia of Once-Common Things Passing Us By_ | Anna Jane Grossman | [Amazon](https://www.amazon.com/dp/0810978490?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6518331) | 3.09 | 113
+5-B-28 | _The Nokia Revolution : The Story of an Extraordinary Company That Transformed an Industry_ | Dan Steinbock | [Amazon](https://www.amazon.com/dp/081440636X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/327478) | 3.08 | 13
+7-E-13 | _Tomcat: The Definitive Guide_ | Jason Brittain, Ian F. Darwin | [Amazon](https://www.amazon.com/dp/0596101066?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/354581) | 3.08 | 24
+1-D-13 | _The Forgotten Network: DuMont and the Birth of American Television_ |  | [Amazon](https://www.amazon.com/dp/1592134998?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/725112) | 3.07 | 14
+4-D-3 | _Web 2.0 and Beyond: Principles and Technologies_ | Paul Anderson | [Amazon](https://www.amazon.com/dp/1439828679?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2187505) | 3.06 | 33
+4-D-19 | _Java Design Patterns_ | James W. Cooper | [Amazon](https://www.amazon.com/dp/0201485397?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/475633) | 3.06 | 17
+1-A-14 | _Coming Attractions?: Hollywood, High Tech, and the Future of Entertainment_ | Philip E. Meza | [Amazon](https://www.amazon.com/dp/0804756600?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1209507) | 3.00 | 2
+1-B-25 | _Wizards and Their Wonders: Portraits in Computing_ | Christopher Morgan, Louis Fabian Bachrach | [Amazon](https://www.amazon.com/dp/0897919602?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5099057) | 3.00 | 1
+2-B-22 | _Zappos.com 2011 Culture Book_ | XL; Zappos | [Amazon](https://www.amazon.com/dp/0692015477?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/18891619) | 3.00 | 2
+3-D-9 | _The Problem of Information_ | Douglas Raber | [Amazon](https://www.amazon.com/dp/0810845687?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5036293) | 3.00 | 10
+3-D-14 | _Who's Afraid of Big Blue: How Companies Are Challenging IBM--and Winning_ | Regis McKenna | [Amazon](https://www.amazon.com/dp/B01FGPFWR4?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1500703) | 3.00 | 2
+4-B-33 | _Call Me Roger_ | Albert Lee |  \| [Goodreads](https://www.goodreads.com/book/show/5996459) | 3.00 | 3
+4-F-13 | _Pro Smartphone Cross-Platform Development: iPhone, Blackberry, Windows Mobile and Android Development and Distribution_ | Sarah Allen, Vidal Graupera,  Lee Lundrigan | [Amazon](https://www.amazon.com/dp/1430228687?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/11342660) | 3.00 | 1
+5-B-3 | _Approaching Quantum Computing_ | Dan C. Marinescu, Gabriela M. Marinescu | [Amazon](https://www.amazon.com/dp/013145224X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/5724386) | 3.00 | 1
+5-B-19 | _Boilerplate Reich_ | W. S. Marble |  \| [Goodreads](https://www.goodreads.com/book/show/14416699) | 3.00 | 2
+5-C-7 | _Information Technology Essentials: Basic Foundations for Information Technology Professionals_ | Eric Frick | [Amazon](https://www.amazon.com/dp/1521576416?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/35216734) | 3.00 | 3
+5-C-22 | _Bill & Dave's Memos_ | Albert Yuen | [Amazon](https://www.amazon.com/dp/1424327814?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/962548) | 3.00 | 2
+7-B-7 | _Linux Cluster Architecture_ | Alex Vrenios | [Amazon](https://www.amazon.com/dp/0672323680?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2064013) | 3.00 | 2
+7-B-22 | _SUSE Linux 9 Bible_ | Justin Davies, Roger Whittaker,  William von Hagen | [Amazon](https://www.amazon.com/dp/0764577395?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1611780) | 3.00 | 2
+7-C-5 | _Inside .Mac: Making the Most of Your .Mac Membership_ | Chuck Toporek | [Amazon](https://www.amazon.com/dp/0596005016?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1604335) | 3.00 | 2
+7-C-8 | _Hacking Mac OS X Tiger: Serious Hacks, Mods and Customizations (ExtremeTech)_ | Scott Knaster | [Amazon](https://www.amazon.com/dp/076458345X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1538756) | 3.00 | 8
+7-C-9 | _The Mac OS X.2 Power User's Book_ | Gene Steinberg, Pieter Paulson | [Amazon](https://www.amazon.com/dp/1932111808?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2166549) | 3.00 | 1
+7-C-22 | _Enterprise System Architectures: Building Client Server and Web Based Systems_ | Mark Goodyear | [Amazon](https://www.amazon.com/dp/0849398363?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/8609513) | 3.00 | 2
+7-E-19 | _The Zope Book_ | Amos Latteier, Michel Pelletier | [Amazon](https://www.amazon.com/dp/0735711372?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/853029) | 3.00 | 12
+3-B-17 | _Who Killed Art Deco?_ | Chuck Barris | [Amazon](https://www.amazon.com/dp/1416575596?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6461770) | 2.96 | 49
+5-E-6 | _Bad Boy Ballmer: The Man Who Rules Microsoft_ | Fredric Alan Maxwell | [Amazon](https://www.amazon.com/dp/0066210143?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/616892) | 2.94 | 17
+5-D-13 | _Quantum Computing (Natural Computing Series)_ | Mika Hirvensalo | [Amazon](https://www.amazon.com/dp/3540407049?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/374293) | 2.88 | 7
+2-F-23 | _Inside The Cult Of Kibu: And Other Tales Of The Millennial Gold Rush_ | Lori Gottlieb, Jesse Jacobs | [Amazon](https://www.amazon.com/dp/0738206911?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/974823) | 2.83 | 6
+3-D-29 | _SAP: Inside the Secret Software Power_ | Gerd Meissner | [Amazon](https://www.amazon.com/dp/0071347852?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1932190) | 2.83 | 6
+1-D-8 | _From Daytime to Primetime: The History of American Television Programs_ | James Roman |  \| [Goodreads](https://www.goodreads.com/book/show/7783172) | 2.75 | 3
+2-F-1 | _Developing with Google App Engine_ | Eugene Ciurana | [Amazon](https://www.amazon.com/dp/1430218312?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6071845) | 2.75 | 7
+2-F-2 | _Developing with Google App Engine_ | Eugene Ciurana | [Amazon](https://www.amazon.com/dp/1430218312?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/6071845) | 2.75 | 7
+3-D-17 | _Howard Aiken: Portrait of a Computer Pioneer_ | I. Bernard Cohen | [Amazon](https://www.amazon.com/dp/0262032627?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1290416) | 2.60 | 5
+7-E-23 | _Building Portals with the Java Portlet API (Expert's Voice)_ | Dave Minter,  Jeff Linwood | [Amazon](https://www.amazon.com/dp/1590592840?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1652954) | 2.50 | 2
+7-E-20 | _Plone Content Management Essentials_ | Julie C. Meloni | [Amazon](https://www.amazon.com/dp/0672326876?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/853019) | 2.29 | 7
+5-B-22 | _Beginning Java Google App Engine (Expert's Voice in Cloud Computing)_ | Kyle Roche, Jeff Douglas | [Amazon](https://www.amazon.com/dp/143022553X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/7244454) | 2.17 | 5
+3-D-4 | _Information and the Origin of Life_ | Bernd-Olaf Kppers | [Amazon](https://www.amazon.com/dp/026211142X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2591851) | 2.00 | 1
+4-F-25 | _Information and Secrecy : Vannevar Bush, Ultra, and the Other Memex_ | Colin Burke | [Amazon](https://www.amazon.com/dp/0810827832?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1708361) | 2.00 | 1
+7-E-21 | _Zope Web Application Construction Kit_ | Martina Brockmann, Katrin Kirchner,  Sebastian Lhnsdorf, Mark Pratt | [Amazon](https://www.amazon.com/dp/0672321335?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/853034) | 2.00 | 1
+7-E-17 | _Cocoon Developer's Handbook_ | Lajos Moczar, Jeremy Aston | [Amazon](https://www.amazon.com/dp/0672322579?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1668183) | 1.67 | 3
+1-A-1 | _Red Blood and Black Ink: Journalism in the Old West_ | David Dary | [Amazon](https://www.amazon.com/dp/B01JXSWSQ8?tag=ba0104-20) \| | 0.0 | 0
+1-A-15 | _Fast Forward: Hollywood, the Japanese, and the Onslaught of the Vcr_ | James Lardner | [Amazon](https://www.amazon.com/dp/B01FKUOS34?tag=ba0104-20) \| | 0.0 | 0
+1-B-3 | _Legacy_ | James Kerr | [Amazon](https://www.amazon.com/dp/147210353X?tag=ba0104-20) \| | 0.0 | 0
+1-B-6 | _The Autobiography of Lincoln Steffens: Complete in One Volume_ | Lincoln Steffens | [Amazon](https://www.amazon.com/dp/0781283604?tag=ba0104-20) \| | 0.0 | 0
+1-B-12 | [illegible] |  |  \| | 0.0 | 0
+1-B-17 | _Personal History_ | Katharine Graham | [Amazon](https://www.amazon.com/dp/0375701044?tag=ba0104-20) \| | 0.0 | 0
+1-B-18 | _All the President's Men by Carl Berstein and Bob Woodward_ | Bob Woodward Carl Bernstein | [Amazon](https://www.amazon.com/dp/B007CKLSZW?tag=ba0104-20) \| | 0.0 | 0
+1-C-1 | _The Telephone book : Bell, Watson, Vail, and American life, 1876-1983_ | H. M. Boettinger, Richard A. Steinberg | [Amazon](https://www.amazon.com/dp/0961218606?tag=ba0104-20) \| | 0.0 | 0
+1-C-9 | _Thinking big: The story of the Los Angeles times, its publishers, and their influence on Southern Ca_ | Robert Gottlieb | [Amazon](https://www.amazon.com/dp/B00SCV1D14?tag=ba0104-20) \| | 0.0 | 0
+1-C-12 | _Lee De Forest and the Fatherhood of Radio_ | James A. Hijiya | [Amazon](https://www.amazon.com/dp/0934223238?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/14521430) | 0.00 | 0
+1-C-18 | _Empire of the Air: The Men Who Made Radio_ | Tom Lewis | [Amazon](https://www.amazon.com/dp/B011SJBAM8?tag=ba0104-20) \| | 0.0 | 0
+1-C-25 | _A Tower in Babel (A History of Broadcasting in the United States to 1933, Vol. 1)_ | Erik Barnouw | [Amazon](https://www.amazon.com/dp/0195004744?tag=ba0104-20) \| | 0.0 | 0
+1-C-27 | _The Image Empire: A History of Broadcasting in the United States, Vol. 3: From 1953_ | Erik Barnouw | [Amazon](https://www.amazon.com/dp/0195012593?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/16801021) | 0.00 | 0
+1-C-28 | _Only Connect: A Cultural History of Broadcasting in the United States_ | Michele Hilmes | [Amazon](https://www.amazon.com/dp/1133307302?tag=ba0104-20) \| | 0.0 | 0
+1-C-29 | _Poor Charlie's Almanack: The Wit and Wisdom of Charles T. Munger, Expanded Third Edition_ | Peter D. Kaufman and_Ed Wexler | [Amazon](https://www.amazon.com/dp/1578645018?tag=ba0104-20) \| | 0.0 | 0
+1-D-5 | _Defining Vision: The battle for the future of Television_ | Joel Brinkley | [Amazon](https://www.amazon.com/dp/0151000875?tag=ba0104-20) \| | 0.0 | 0
+1-D-9 | _Bowls of Plenty: Recipes for Healthy and Delicious Whole-Grain Meals_ | Carolynn Carreno,  Nancy Silverton |  \| | 0.0 | 0
+1-D-17 | _Best Seat In The House, The: The Golden Years of Radio and Television_ | Pat Weaver |  \| | 0.0 | 0
+2-B-1 | _Hollywood East: Louis B. Mayer and the origins of the studio system_ | Diana Altman | [Amazon](https://www.amazon.com/dp/0982890206?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/10224815) | 0.00 | 0
+2-B-23 | _Zappos.com 2012- 2013 Culture Book_ |  |  \| | 0.0 | 0
+2-C-28 | _Keith Tyson: Fractal Dice_ | Keith Tyson | [Amazon](https://www.amazon.com/dp/1930743904?tag=ba0104-20) \| | 0.0 | 0
+2-D-1 | _Keith Tyson: Large Field Array_ | Michael Holm, Dominic van den Boogerd, Keith Tyson | [Amazon](https://www.amazon.com/dp/B01HCAVM3Y?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2093806) | 0.00 | 0
+2-D-4 | _Naked Conversations: How Blogs are Changing the Way Businesses Talk with Customers_ | Robert Scoble, Shel Israel | [Amazon](https://www.amazon.com/dp/047174719X?tag=ba0104-20) \| | 0.0 | 0
+2-D-7 | _Walt Disney: The Triumph of the American Imagination_ | Neal Gabler | [Amazon](https://www.amazon.com/dp/0679757473?tag=ba0104-20) \| | 0.0 | 0
+2-D-9 | [illegible] |  |  \| | 0.0 | 0
+2-D-11 | _The Big Picture: Money and Power in Hollywood_ | Edward Jay Epstein | [Amazon](https://www.amazon.com/dp/0812973828?tag=ba0104-20) \| | 0.0 | 0
+2-E-1 | _Five Easy Decades: How Jack Nicholson Became the Biggest Movie Star in Modern Times_ | Dennis McDougal |  \| | 0.0 | 0
+2-E-20 | _High Tech Start Up, Revised and Updated: The Complete Handbook For Creating Successful New High Tech Companies_ | John L. Nesheim | [Amazon](https://www.amazon.com/dp/068487170X?tag=ba0104-20) \| | 0.0 | 0
+2-E-24 | _Seeing What's Next: Using Theories of Innovation to Predict Industry Change_ | Clayton M. Christensen, Erik A. Roth | [Amazon](https://www.amazon.com/dp/1591391857?tag=ba0104-20) \| | 0.0 | 0
+2-E-28 | _The Last Mogul: Lew Wasserman, MCA, and the Hidden History of Hollywood_ | Dennis McDougal | [Amazon](https://www.amazon.com/dp/B019NDM02U?tag=ba0104-20) \| | 0.0 | 0
+2-F-13 | _The History of the Telephone_ | Herbert N. Casson | [Amazon](https://www.amazon.com/dp/1596058838?tag=ba0104-20) \| | 0.0 | 0
+2-F-29 | _[not visible]_ |  |  \| | 0.0 | 0
+3-A-18 | _The Operator: David Geffen Builds, Buys, and Sells the New Hollywood_ | Tom King | [Amazon](https://www.amazon.com/dp/0679457542?tag=ba0104-20) \| | 0.0 | 0
+3-A-19 | _The Operator: David Geffen Builds, Buys, and Sells the New Hollywood_ | Tom King | [Amazon](https://www.amazon.com/dp/0679457542?tag=ba0104-20) \| | 0.0 | 0
+3-B-4 | _A Mencken Chrestomathy: A Selection from H.L.M.'s out-of-print writings._ | H. L. Mencken | [Amazon](https://www.amazon.com/dp/B000YHJ3V6?tag=ba0104-20) \| | 0.0 | 0
+3-B-5 | _A Second Mencken Chrestomathy_ | H. L. Mencken | [Amazon](https://www.amazon.com/dp/0679428291?tag=ba0104-20) \| | 0.0 | 0
+3-B-7 | _The Groucho Letters: Letters from and to Groucho Marx_ | Groucho Marx | [Amazon](https://www.amazon.com/dp/1416536035?tag=ba0104-20) \| | 0.0 | 0
+3-B-12 | _Hitchcock_ | H. Truffaut | [Amazon](https://www.amazon.com/dp/B0045MHAHA?tag=ba0104-20) \| | 0.0 | 0
+3-B-22 | _The Life of Charles Chaplin_ | Joyce Milton | [Amazon](https://www.amazon.com/dp/0060170522?tag=ba0104-20) \| | 0.0 | 0
+3-C-4 | _Instant Pogo: Getting Mr. Pig's Goat, A Sequel to The Jack Acid Society Black Book__ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B000AS31X0?tag=ba0104-20) \| | 0.0 | 0
+3-C-10 | _[not visible]_ |  |  \| | 0.0 | 0
+3-C-11 | [illegible] |  |  \| | 0.0 | 0
+3-C-12 | _Impollutable Pogo_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/0671804014?tag=ba0104-20) \| | 0.0 | 0
+3-C-19 | _Pogo Re-Runs_ | Walt Kelly | [Amazon](https://www.amazon.com/dp/B019NRFLN6?tag=ba0104-20) \| | 0.0 | 0
+3-C-24 | [illegible] |  |  \| | 0.0 | 0
+3-D-1 | _John Von Neumann, 1903-1957: Bulletin of the American Mathematical Society, V64, No. 3, Part 2,_ | John C. Oxtoby,  Billy J. Pettis,  G. B. Price | [Amazon](https://www.amazon.com/dp/1258713101?tag=ba0104-20) \| | 0.0 | 0
+3-D-13 | _Keith Tyson: Nature Paintings by Gabriel Ramin Schor_ | Gabriel Ramin Schor_ | [Amazon](https://www.amazon.com/dp/B01K92W2ZE?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/2949105) | 0.00 | 0
+3-D-22 | _The Games-Man: The New Corporate Leaders_ | Michael Maccoby | [Amazon](https://www.amazon.com/dp/B000H40ETG?tag=ba0104-20) \| | 0.0 | 0
+3-D-23 | _Computers and Commerce_ | Arthur L. Norberg | [Amazon](https://www.amazon.com/dp/026214090X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/4249913) | 0.00 | 0
+3-D-28 | _War on Whistleblowers: Free Press and the National Security State_ | Michael DeKort, Thomas Drake, Robert Greenwald | [Amazon](https://www.amazon.com/dp/B00I8VQ53E?tag=ba0104-20) \| | 0.0 | 0
+3-E-6 | _The Jasons: The Secret History of Science's Postwar Elite_ | Ann Finkbeiner_ | [Amazon](https://www.amazon.com/dp/0670034894?tag=ba0104-20) \| | 0.0 | 0
+3-E-12 | _Information for everyone: The Applied Materials story, 1967-2002_ | Applied Materials Technology | [Amazon](https://www.amazon.com/dp/B009O3G1K2?tag=ba0104-20) \| | 0.0 | 0
+3-E-19 | _Building IBM: Shaping an Industry and Its Technology (History of Computing)_ | Emerson W. Pugh | [Amazon](https://www.amazon.com/dp/0262512823?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/11408032) | 0.00 | 0
+3-E-21 | _Swimming Across: A Memoir_ | Andrew S. Grove | [Amazon](https://www.amazon.com/dp/0446528595?tag=ba0104-20) \| | 0.0 | 0
+3-E-23 | _Spinoff 2008: 50 Years of NASA-Derived Technologies (1958-2008)_ | National Aeronautics and Space Administration | [Amazon](https://www.amazon.com/dp/1494771020?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/32727632) | 0.00 | 0
+3-F-6 | _The Soul of a New Machine_ |  |  \| | 0.0 | 0
+3-F-9 | _The Facebook Era: Tapping Online Social Networks to Build Better Products, Reach New Audiences, and Sell More Stuff_ | Clara Shih_ | [Amazon](https://www.amazon.com/dp/0137152221?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/22251572) | 0.00 | 0
+3-F-22 | _Only the Paranoid Survive: How to Exploit the Crisis Points That Challenge Every Company_ | Andrew S. Grove | [Amazon](https://www.amazon.com/dp/0385483821?tag=ba0104-20) \| | 0.0 | 0
+3-F-26 | _Startup: A Silicon Valley Adventure_ | S. Jerrold Kaplan | [Amazon](https://www.amazon.com/dp/0395711339?tag=ba0104-20) \| | 0.0 | 0
+4-A-1 | _[not visible]_ |  |  \| | 0.0 | 0
+4-A-3 | [illegible] |  |  \| | 0.0 | 0
+4-A-4 | _Evolution in Four Dimensions: Genetic, Epigenetic, Behavioral, and Symbolic Variation in the History of Life_ | y Eva Jablonka,  Marion J. Lamb, Anna Zeligowski | [Amazon](https://www.amazon.com/dp/0262525844?tag=ba0104-20) \| | 0.0 | 0
+4-A-6 | [illegible] |  |  \| | 0.0 | 0
+4-A-8 | _[not visible]_ |  |  \| | 0.0 | 0
+4-A-9 | _[not visible]_ |  |  \| | 0.0 | 0
+4-A-12 | [illegible] |  |  \| | 0.0 | 0
+4-A-13 | _Computers For Seniors For Dummies (For Dummies (Computer/Tech))_ | Nancy C. Muir | [Amazon](https://www.amazon.com/dp/1119420318?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/36213972) | 0.00 | 0
+4-A-15 | _Electronic Brains_ | Mike Hally Square Dog Radio, Mark Whitaker (Narrator), & 1 more | [Amazon](https://www.amazon.com/dp/B00BS3EM7A?tag=ba0104-20) \| | 0.0 | 0
+4-A-16 | [illegible] |  |  \| | 0.0 | 0
+4-A-17 | [illegible] |  |  \| | 0.0 | 0
+4-A-20 | _A History of Modern Computing (History of Computing)_ | Paul E. Ceruzz | [Amazon](https://www.amazon.com/dp/0262032554?tag=ba0104-20) \| | 0.0 | 0
+4-A-24 | [illegible] |  |  \| | 0.0 | 0
+4-A-29 | [illegible] |  |  \| | 0.0 | 0
+4-A-32 | [illegible] |  |  \| | 0.0 | 0
+4-B-2 | [illegible] |  |  \| | 0.0 | 0
+4-B-7 | _Principles of Quantum Computation and Information_ | Giuliano Benenti, Giulio Casati, Giuliano Strini | [Amazon](https://www.amazon.com/dp/9812565280?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1642691) | 0.00 | 0
+4-B-9 | _Commutation Relations, Normal Ordering, and Stirling Numbers_ | Toufik Mansour, Matthias Schork | [Amazon](https://www.amazon.com/dp/1466579889?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/26761287) | 0.00 | 0
+4-B-11 | _Wireless Networking Complete (Morgan Kaufmann Series in Networking_ | Pei Zheng, Larry L. Peterson, Bruce S. Davie, Adrian Farrel |  \| [Goodreads](https://www.goodreads.com/book/show/6839954) | 0.00 | 0
+4-B-12 | _[not visible]_ |  |  \| | 0.0 | 0
+4-B-23 | [illegible] |  |  \| | 0.0 | 0
+4-B-25 | [illegible] |  |  \| | 0.0 | 0
+4-B-29 | [illegible] |  |  \| | 0.0 | 0
+4-B-32 | [illegible] |  |  \| | 0.0 | 0
+4-C-10 | [illegible] |  |  \| | 0.0 | 0
+4-C-11 | [illegible] |  |  \| | 0.0 | 0
+4-C-12 | _Google Advertising Tools: Cashing in with AdSense, AdWords, and the Google APIs_ | Harold Davis | [Amazon](https://www.amazon.com/dp/0596101082?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/28328093) | 0.00 | 0
+4-C-14 | _Microprocessor Design_ | Grant McFarland |  \| [Goodreads](https://www.goodreads.com/book/show/16791888) | 0.00 | 0
+4-C-25 | [illegible] |  |  \| | 0.0 | 0
+4-C-27 | [illegible] |  |  \| | 0.0 | 0
+4-C-28 | _[not visible]_ |  |  \| | 0.0 | 0
+4-C-29 | _[not visible]_ |  |  \| | 0.0 | 0
+4-D-9 | _Data Structures and Problem Solving Using Java_ | Mark Allen Weiss | [Amazon](https://www.amazon.com/dp/0321322134?tag=ba0104-20) \| | 0.0 | 0
+4-D-12 | _Design Patterns in Java_ | Steven John Metsker, William C. Wake |  \| | 0.0 | 0
+4-D-21 | [illegible] |  |  \| | 0.0 | 0
+4-D-24 | [illegible] |  |  \| | 0.0 | 0
+4-D-26 | [illegible] |  |  \| | 0.0 | 0
+4-E-16 | [illegible] |  |  \| | 0.0 | 0
+4-E-17 | [illegible] |  |  \| | 0.0 | 0
+4-E-20 | [illegible] |  |  \| | 0.0 | 0
+4-E-25 | [illegible] |  |  \| | 0.0 | 0
+4-E-28 | [illegible] |  |  \| | 0.0 | 0
+4-F-3 | [illegible] |  |  \| | 0.0 | 0
+4-F-6 | [illegible] |  |  \| | 0.0 | 0
+4-F-16 | _Healing Energies of Heat and Light: A Quantum Leap in Health Care_ | Charles T. McGee MD | [Amazon](https://www.amazon.com/dp/096369796X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/888610) | 0.00 | 0
+4-F-20 | _[not visible]_ |  |  \| | 0.0 | 0
+4-F-22 | [illegible] |  |  \| | 0.0 | 0
+4-F-23 | [illegible] |  |  \| | 0.0 | 0
+4-F-27 | _[not visible]_ |  |  \| | 0.0 | 0
+4-F-28 | [illegible] |  |  \| | 0.0 | 0
+4-F-31 | _The Big Score: The Billion Dollar Story of Silicon Valley_ | Michael S. Malone | [Amazon](https://www.amazon.com/dp/0385183518?tag=ba0104-20) \| | 0.0 | 0
+5-A-1 | [illegible] |  |  \| | 0.0 | 0
+5-A-6 | [illegible] |  |  \| | 0.0 | 0
+5-A-7 | [illegible] |  |  \| | 0.0 | 0
+5-A-8 | [illegible] |  |  \| | 0.0 | 0
+5-A-9 | [illegible] |  |  \| | 0.0 | 0
+5-A-11 | [illegible] |  |  \| | 0.0 | 0
+5-A-14 | [illegible] |  |  \| | 0.0 | 0
+5-A-18 | [illegible] |  |  \| | 0.0 | 0
+5-A-22 | _Network Routing, Second Edition: Algorithms, Protocols, and Architectures_ | Deep Medhi, Karthik Ramasamy | [Amazon](https://www.amazon.com/dp/0128007370?tag=ba0104-20) \| | 0.0 | 0
+5-A-24 | [illegible] |  |  \| | 0.0 | 0
+5-A-25 | [illegible] |  |  \| | 0.0 | 0
+5-A-27 | [illegible] |  |  \| | 0.0 | 0
+5-A-28 | _Going Public: MIPS Computer and the Entrepreneurial Dream_ | Michael S. Malone | [Amazon](https://www.amazon.com/dp/0060165197?tag=ba0104-20) \| | 0.0 | 0
+5-A-30 | [illegible] |  |  \| | 0.0 | 0
+5-A-31 | _[not visible]_ |  |  \| | 0.0 | 0
+5-A-32 | [illegible] |  |  \| | 0.0 | 0
+5-A-33 | _Inventing the Internet_ | Janet Abbate | [Amazon](https://www.amazon.com/dp/0262011727?tag=ba0104-20) \| | 0.0 | 0
+5-B-7 | [illegible] |  |  \| | 0.0 | 0
+5-B-9 | [illegible] |  |  \| | 0.0 | 0
+5-B-11 | [illegible] |  |  \| | 0.0 | 0
+5-B-12 | [illegible] |  |  \| | 0.0 | 0
+5-B-13 | [illegible] |  |  \| | 0.0 | 0
+5-B-15 | [illegible] |  |  \| | 0.0 | 0
+5-B-16 | [illegible] |  |  \| | 0.0 | 0
+5-B-21 | [illegible] |  |  \| | 0.0 | 0
+5-B-24 | [illegible] |  |  \| | 0.0 | 0
+5-B-25 | [illegible] |  |  \| | 0.0 | 0
+5-B-32 | [illegible] |  |  \| | 0.0 | 0
+5-B-33 | [illegible] |  |  \| | 0.0 | 0
+5-B-34 | [illegible] |  |  \| | 0.0 | 0
+5-C-1 | [illegible] |  |  \| | 0.0 | 0
+5-C-3 | [illegible] |  |  \| | 0.0 | 0
+5-C-4 | [illegible] |  |  \| | 0.0 | 0
+5-C-5 | _Information Processing and Living Systems_ | Vladimir B. Bajic, Tan Tin Wee | [Amazon](https://www.amazon.com/dp/1860945635?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/783354) | 0.00 | 0
+5-C-10 | [illegible] |  |  \| | 0.0 | 0
+5-C-11 | _Bringing Design to Software_ | Terry Winograd | [Amazon](https://www.amazon.com/dp/0201854910?tag=ba0104-20) \| | 0.0 | 0
+5-C-15 | [illegible] |  |  \| | 0.0 | 0
+5-C-16 | [illegible] |  |  \| | 0.0 | 0
+5-C-18 | [illegible] |  |  \| | 0.0 | 0
+5-C-19 | [illegible] |  |  \| | 0.0 | 0
+5-C-29 | [illegible] |  |  \| | 0.0 | 0
+5-C-32 | [illegible] |  |  \| | 0.0 | 0
+5-C-34 | [illegible] |  |  \| | 0.0 | 0
+5-D-3 | _[not visible]_ |  |  \| | 0.0 | 0
+5-D-5 | [illegible] |  |  \| | 0.0 | 0
+5-D-6 | [illegible] |  |  \| | 0.0 | 0
+5-D-7 | [illegible] |  |  \| | 0.0 | 0
+5-D-14 | [illegible] |  |  \| | 0.0 | 0
+5-D-22 | _Introducing Windows Azure (Expert's Voice in .NET)_ | Henry Li | [Amazon](https://www.amazon.com/dp/143022469X?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/21265047) | 0.00 | 0
+5-D-23 | [illegible] |  |  \| | 0.0 | 0
+5-D-24 | [illegible] |  |  \| | 0.0 | 0
+5-D-33 | [illegible] |  |  \| | 0.0 | 0
+5-D-35 | [illegible] |  |  \| | 0.0 | 0
+5-E-1 | [illegible] |  |  \| | 0.0 | 0
+5-E-4 | [illegible] |  |  \| | 0.0 | 0
+5-E-5 | _Irreconcilable Differences: Profiles of the Founding Fathers 1750-1776 (The American Patriots Series)_ | Leslie G. Mironuck, Jim Simmons M.Ed. | [Amazon](https://www.amazon.com/dp/0997662506?tag=ba0104-20) \| | 0.0 | 0
+5-E-9 | [illegible] |  |  \| | 0.0 | 0
+5-E-10 | _Communication: How to Speak Effectively and Improve Your Relationships, Problem Solving, Listening, and Social Skills_ | Eric Davenport | [Amazon](https://www.amazon.com/dp/1522857761?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/28630127) | 0.00 | 0
+5-E-13 | [illegible] |  |  \| | 0.0 | 0
+5-E-14 | [illegible] |  |  \| | 0.0 | 0
+5-E-16 | [illegible] |  |  \| | 0.0 | 0
+5-E-17 | _Claude E. Shannon: Collected Papers_ | Claude Elwood Shannon, A. D. Wyner, Neil J. A. Sloane | [Amazon](https://www.amazon.com/dp/0780304349?tag=ba0104-20) \| | 0.0 | 0
+5-E-19 | [illegible] |  |  \| | 0.0 | 0
+5-E-30 | [illegible] |  |  \| | 0.0 | 0
+5-F-1 | [illegible] |  |  \| | 0.0 | 0
+5-F-3 | _Total Recall - Special Edition_ | Arnold Schwarzenegger | [Amazon](https://www.amazon.com/dp/6306529039?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/25928651) | 0.00 | 0
+5-F-5 | [illegible] |  |  \| | 0.0 | 0
+5-F-6 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-7 | [illegible] |  |  \| | 0.0 | 0
+5-F-8 | [illegible] |  |  \| | 0.0 | 0
+5-F-9 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-10 | [illegible] |  |  \| | 0.0 | 0
+5-F-11 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-12 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-13 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-14 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-15 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-16 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-17 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-18 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-19 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-20 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-21 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-22 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-23 | _[not visible]_ |  |  \| | 0.0 | 0
+5-F-24 | _[not visible]_ |  |  \| | 0.0 | 0
+7-A-2 | [illegible] |  |  \| | 0.0 | 0
+7-A-3 | [illegible] |  |  \| | 0.0 | 0
+7-A-5 | [illegible] |  |  \| | 0.0 | 0
+7-A-12 | [illegible] |  |  \| | 0.0 | 0
+7-A-16 | [illegible] |  |  \| | 0.0 | 0
+7-A-17 | [illegible] |  |  \| | 0.0 | 0
+7-A-18 | [illegible] |  |  \| | 0.0 | 0
+7-A-22 | [illegible] |  |  \| | 0.0 | 0
+7-A-23 | [illegible] |  |  \| | 0.0 | 0
+7-C-17 | [illegible] |  |  \| | 0.0 | 0
+7-D-4 | _Windows XP Unwired_ | Wei Meng Lee | [Amazon](https://www.amazon.com/dp/0596005369?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/1644333) | 0.00 | 0
+7-D-6 | _Special Edition Using Microsoft Windows XP Professional_ | Robert Cowart,  Brian Knittel | [Amazon](https://www.amazon.com/dp/0789732807?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/20958296) | 0.00 | 0
+7-D-11 | [illegible] |  |  \| | 0.0 | 0
+7-E-1 | [illegible] |  |  \| | 0.0 | 0
+7-E-2 | [illegible] |  |  \| | 0.0 | 0
+7-E-3 | [illegible] |  |  \| | 0.0 | 0
+7-E-4 | [illegible] |  |  \| | 0.0 | 0
+7-E-5 | [illegible] |  |  \| | 0.0 | 0
+7-E-7 | [illegible] |  |  \| | 0.0 | 0
+7-E-15 | _Pro Jakarta Commons_ | Harshad Oak, Apress | [Amazon](https://www.amazon.com/dp/1590592832?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/24427241) | 0.00 | 0
+7-E-26 | [illegible] |  |  \| | 0.0 | 0
+7-E-31 | _Apache Jakarta and Beyond: A Java Programmer's Introduction_ | Larne Pekowsky | [Amazon](https://www.amazon.com/dp/B008SMP1BU?tag=ba0104-20) \| | 0.0 | 0
+8-A-1 | [illegible] |  |  \| | 0.0 | 0
+8-A-6 | _Artificial Intelligence: A Modern Approach (3rd Edition)_ | Stuart Russell, Peter Norvig | [Amazon](https://www.amazon.com/dp/0136042597?tag=ba0104-20) \| | 0.0 | 0
+8-A-18 | [illegible] |  |  \| | 0.0 | 0
+8-A-19 | [illegible] |  |  \| | 0.0 | 0
+8-A-20 | [illegible] |  |  \| | 0.0 | 0
+8-B-1 | [illegible] |  |  \| | 0.0 | 0
+8-B-2 | [illegible] |  |  \| | 0.0 | 0
+8-C-13 | [illegible] |  |  \| | 0.0 | 0
+8-D-1 | [illegible] |  |  \| | 0.0 | 0
+8-D-2 | [illegible] |  |  \| | 0.0 | 0
+8-D-3 | [illegible] |  |  \| | 0.0 | 0
+8-D-4 | [illegible] |  |  \| | 0.0 | 0
+8-D-12 | [illegible] |  |  \| | 0.0 | 0
+8-D-14 | [illegible] |  |  \| | 0.0 | 0
+8-D-15 | [illegible] |  |  \| | 0.0 | 0
+8-D-16 | [illegible] |  |  \| | 0.0 | 0
+8-D-19 | [illegible] |  |  \| | 0.0 | 0
+8-D-21 | [illegible] |  |  \| | 0.0 | 0
+8-D-28 | [illegible] |  |  \| | 0.0 | 0
+8-D-30 | [illegible] |  |  \| | 0.0 | 0
+8-E-5 | [illegible] |  |  \| | 0.0 | 0
+8-E-6 | _The House of Klein: Fashion, Controversy, and a Business Obsession_ | Lisa Marsh | [Amazon](https://www.amazon.com/dp/B01FGIL3C4?tag=ba0104-20) \| [Goodreads](https://www.goodreads.com/book/show/9548899) | 0.00 | 0
+8-E-9 | [illegible] |  |  \| | 0.0 | 0
+8-E-18 | [illegible] |  |  \| | 0.0 | 0
+8-E-36 | [illegible] |  |  \| | 0.0 | 0


### PR DESCRIPTION
- added simple script to use the Goodreads API to get the rating and rating counts for the books in the library
- added the output of the script: an extended markdown table showing the books in the library with the  average rating on Goodreads and the count of ratings provided. The table is sorted form highest to lowest rating